### PR TITLE
Don't do DCG on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 
 # The directory label is used for CDash to treat DILL as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS DILL)
@@ -156,8 +156,14 @@ else()
   set(DILL_NATIVE_ONLY_DEFAULT OFF)
 endif()
 
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin|Linux")
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(USE_MMAP_CODE_SEG 1)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  message(STATUS "DILL - NO Native CG without code signing on Darwin")
+  set(NATIVE_CG FALSE)
+  set(NATIVE_ARCH UNSUPPORTED)
+  set(DILL_IGNORE_NATIVE ON)
+  set(DILL_NATIVE_ONLY_DEFAULT OFF)
 elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
   set(USE_VIRTUAL_PROTECT 1)
   set(USE_WINDOWS_CALLS 1)

--- a/virtual.c
+++ b/virtual.c
@@ -4476,6 +4476,8 @@ virtual_do_end(dill_stream s, int package)
         if (vmi->prefix_code_start == -1) {
             dill_retii(s, 0);
             s->p->virtual.cur_ip = s->p->cur_ip;
+	    s->p->virtual.code_base = s->p->code_base;
+	    s->p->virtual.code_limit = s->p->code_limit;
         }
         setup_VM_proc(s);
 #endif


### PR DESCRIPTION
Disable DCG on OSX until such a time as the memory signing issue is worked out.