### PR TITLE
Modernize CMake practices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 # The directory label is used for CDash to treat DILL as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS DILL)
 
-project(DILL VERSION 3.1.3 LANGUAGES C CXX)
+project(DILL VERSION 3.1.4 LANGUAGES C CXX)
 
 # Some boilerplate to setup nice output directories
 include(GNUInstallDirs)
@@ -38,20 +38,13 @@ endif()
 if(NOT DEFINED DILL_HEADER_COMPONENT)
   set(DILL_HEADER_COMPONENT dev)
 endif()
-add_definitions(-DDILL_SRC)
+
 if(WIN32)
   # Automagic to do the DLL / LIB song and dance
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
-  # Silence MSVC warnings
   if(CMAKE_C_COMPILER_ID MATCHES "MSVC" OR
      CMAKE_C_SIMULATE_ID MATCHES "MSVC")
-    add_definitions(
-      -D_CRT_SECURE_NO_DEPRECATE
-      -D_CRT_SECURE_NO_WARNINGS
-      -D_SCL_SECURE_NO_DEPRECATE
-      -D_WINSOCK_DEPRECATED_NO_WARNINGS
-      -D_CRT_NONSTDC_NO_DEPRECATE)
     set (MSVC_PERL_FLAGS "-msvc-long")
   endif()
 endif()
@@ -169,8 +162,11 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
   set(USE_WINDOWS_CALLS 1)
 endif()
 
-include(TestBigEndian)
-test_big_endian(WORDS_BIGENDIAN)
+if(CMAKE_C_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+  set(WORDS_BIGENDIAN 1)
+else()
+  set(WORDS_BIGENDIAN 0)
+endif()
 
 set(HARDFP_AVAILABLE 0)
 # Determine float ABI of ARM Linux
@@ -414,14 +410,13 @@ void main()
     INIT_DISASSEMBLE_INFO_THREE_ARG
   )
 
-  include(CheckFunctionExists)
-  check_function_exists(print_insn_sparc          HAVE_PRINT_INSN_SPARC)
-  check_function_exists(print_insn_big_powerpc    HAVE_PRINT_INSN_BIG_POWERPC)
-  check_function_exists(print_insn_little_powerpc HAVE_PRINT_INSN_LITTLE_POWERPC)
-  check_function_exists(print_insn_ia64           HAVE_PRINT_INSN_IA64)
-  check_function_exists(print_insn_i386           HAVE_PRINT_INSN_I386)
-  check_function_exists(print_insn_arm            HAVE_PRINT_INSN_ARM)
-  check_function_exists(print_insn_little_arm     HAVE_PRINT_INSN_LITTLE_ARM)
+  check_symbol_exists(print_insn_sparc          "dis-asm.h" HAVE_PRINT_INSN_SPARC)
+  check_symbol_exists(print_insn_big_powerpc    "dis-asm.h" HAVE_PRINT_INSN_BIG_POWERPC)
+  check_symbol_exists(print_insn_little_powerpc "dis-asm.h" HAVE_PRINT_INSN_LITTLE_POWERPC)
+  check_symbol_exists(print_insn_ia64           "dis-asm.h" HAVE_PRINT_INSN_IA64)
+  check_symbol_exists(print_insn_i386           "dis-asm.h" HAVE_PRINT_INSN_I386)
+  check_symbol_exists(print_insn_arm            "dis-asm.h" HAVE_PRINT_INSN_ARM)
+  check_symbol_exists(print_insn_little_arm     "dis-asm.h" HAVE_PRINT_INSN_LITTLE_ARM)
 
   cmake_pop_check_state()
 endif()
@@ -437,6 +432,18 @@ set_target_properties(dill PROPERTIES
   VERSION ${DILL_VERSION}
   SOVERSION ${DILL_VERSION_MAJOR})
 add_library(dill::dill ALIAS dill)
+
+target_compile_definitions(dill PRIVATE DILL_SRC)
+
+# MSVC warning suppressions
+if(MSVC OR CMAKE_C_SIMULATE_ID MATCHES "MSVC")
+  target_compile_definitions(dill PRIVATE
+    _CRT_SECURE_NO_DEPRECATE
+    _CRT_SECURE_NO_WARNINGS
+    _SCL_SECURE_NO_DEPRECATE
+    _WINSOCK_DEPRECATED_NO_WARNINGS
+    _CRT_NONSTDC_NO_DEPRECATE)
+endif()
 
 target_include_directories(dill
   PUBLIC
@@ -493,20 +500,16 @@ if(DILL_INSTALL_HEADERS)
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" COMPONENT ${DILL_HEADER_COMPONENT})
 endif()
 
-set(namelink_component_args)
-if(NOT CMAKE_VERSION VERSION_LESS 3.12)
-  set(namelink_component_args NAMELINK_COMPONENT ${DILL_HEADER_COMPONENT})
-endif()
 install(TARGETS dill
   # IMPORTANT: Add the dill library to the "export-set"
   EXPORT dill-targets
   RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"          COMPONENT ${DILL_RUNTIME_COMPONENT}
-  LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"          COMPONENT ${DILL_LIBRARY_COMPONENT} ${namelink_component_args}
+  LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"          COMPONENT ${DILL_LIBRARY_COMPONENT} NAMELINK_COMPONENT ${DILL_HEADER_COMPONENT}
   ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"          COMPONENT ${DILL_ARCHIVE_COMPONENT}
   PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/dill" COMPONENT ${DILL_HEADER_COMPONENT})
 
-if(${CMAKE_C_COMPILER_ID} MATCHES "Intel") 
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -shared-intel")
+if(CMAKE_C_COMPILER_ID MATCHES "Intel")
+  add_link_options(-shared-intel)
 endif()
 
 configure_file(


### PR DESCRIPTION
- Replace deprecated check_function_exists with check_symbol_exists (fixes detection failures with modern compilers)
- Replace deprecated TestBigEndian with CMAKE_C_BYTE_ORDER
- Replace add_definitions with target_compile_definitions for DILL_SRC and MSVC warnings
- Remove unnecessary NAMELINK_COMPONENT version check (requires CMake 3.14)
- Modernize CMAKE_EXE_LINKER_FLAGS to add_link_options for Intel compiler