### PR TITLE
Modernize CI workflow configuration

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,15 +1,17 @@
 name: Build and Test
 
-on: 
-  push: 
-    branches: 
-    - master 
-  pull_request: 
-    branches: 
-    - master 
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  schedule:
+    - cron: '0 6 * * 1'  # Monday 6am UTC - weekly build to catch dependency issues 
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -30,9 +32,6 @@ jobs:
         buildtype: [ release, debug ]
         os: [ alma9, ubuntu2204, ubuntu2404 ]
         compiler: [ clang, gcc ]
-        exclude:
-          - { os: alma9, compiler: nvhpc }
-          - { os: ubuntu2204, compiler: nvhpc }
         include:
         - os: alma9
           container: almalinux:9
@@ -42,12 +41,19 @@ jobs:
           container: ubuntu:22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         path: source
     - name: Setup
       run: source/scripts/ci/setup/linux.sh
+    - name: Cache CMake build
+      uses: actions/cache@v4
+      with:
+        path: build
+        key: ${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.buildtype }}-${{ hashFiles('source/CMakeLists.txt', 'source/**/*.cmake') }}
+        restore-keys: |
+          ${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.buildtype }}-
     - name: Update
       run: source/scripts/ci/gh-actions/run.sh update
     - name: Configure
@@ -88,16 +94,23 @@ jobs:
         shell: bash
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         path: source
-    - name: Setup
+    - name: Setup Windows
       if: ${{ runner.os == 'Windows' }}
       run: source/scripts/ci/setup/windows.sh
-    - name: Setup
+    - name: Setup macOS
       if: ${{ runner.os == 'macOS' }}
       run: source/scripts/ci/setup/macos.sh
+    - name: Cache CMake build
+      uses: actions/cache@v4
+      with:
+        path: build
+        key: ${{ matrix.jobname }}-${{ matrix.buildtype }}-${{ hashFiles('source/CMakeLists.txt', 'source/**/*.cmake') }}
+        restore-keys: |
+          ${{ matrix.jobname }}-${{ matrix.buildtype }}-
     - name: Update
       run: source/scripts/ci/gh-actions/run.sh update
     - name: Configure

--- a/.github/workflows/triggers.yml
+++ b/.github/workflows/triggers.yml
@@ -3,13 +3,15 @@ name: Triggers
 on:
   workflow_run:
     workflows: ["Build and Test"]
-    types: [requested]
+    types: [requested, completed]
 
 jobs:
-  all_triggers:
+  post_cdash_link:
     runs-on: ubuntu-latest
+    # Only post CDash link when workflow completes (results are available)
+    if: ${{ github.event.action == 'completed' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Post CDash Status
       run: scripts/ci/scripts/post-cdash-status.sh ${{ github.event.repository.full_name }} ${{ github.event.workflow_run.head_sha }} ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Update actions/checkout from v2 to v4 (faster, more secure)
- Remove dead nvhpc exclude entries from matrix
- Add build directory caching with actions/cache@v4
- Add weekly scheduled runs (Monday 6am UTC) to catch dependency issues
- Rename duplicate "Setup" steps to "Setup Windows" and "Setup macOS"
- Improve concurrency group to include workflow name
- Fix triggers.yml to post CDash link on workflow completion (not start)