### PR TITLE
Fix Windows x64 code generation for 64-bit types and mixed parameters

### DIFF
--- a/virtual.c
+++ b/virtual.c
@@ -3881,7 +3881,8 @@ is_convert_noop(int insn_code)
     int to_type = insn_code & 0xf;
 
     /* GSE -bug  This test should be for *generated* target, not host */
-    if (sizeof(long) != sizeof(int)) {
+    /* Use sizeof(uintptr_t) since that's what DILL uses for UL/L types */
+    if (sizeof(uintptr_t) != sizeof(int)) {
         return 0;
     } else {
         switch (from_type) {

--- a/vtests/CMakeLists.txt
+++ b/vtests/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(TESTS basic_call general t1 opt branch prefix_test)
+set(TESTS basic_call general t1 opt branch prefix_test mixed_params)
 
 if(NATIVE_CG)
   list(APPEND TESTS pkg_test multi_test)

--- a/vtests/mixed_params.c
+++ b/vtests/mixed_params.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <math.h>
+#include "dill.h"
+#include "config.h"
+
+/* Dump hex bytes of generated code */
+void dump_hex(unsigned char* p, int len) {
+    for (int i = 0; i < len; i++) {
+        printf("%02x ", p[i]);
+        if ((i + 1) % 16 == 0) printf("\n");
+    }
+    printf("\n");
+}
+
+int main() {
+    dill_stream s;
+    dill_reg a, b, tmp;
+    dill_exec_handle h;
+
+    printf("Generating ul+f test (like FFS)...\n");
+
+    s = dill_create_stream();
+    dill_start_proc(s, "no name", DILL_UL, "%ul%f");
+    a = dill_param_reg(s, 0);
+    b = dill_param_reg(s, 1);
+
+    tmp = dill_getreg(s, DILL_F);
+    dill_cvul2f(s, tmp, a);
+    dill_addf(s, tmp, tmp, b);
+    dill_cvf2ul(s, a, tmp);
+    dill_retul(s, a);
+
+    h = dill_finalize(s);
+
+    printf("\nVirtual instruction dump:\n");
+    dill_dump(s);
+
+    unsigned char* code = (unsigned char*)dill_get_fp(h);
+    printf("\nFirst 128 bytes of native code at %p:\n", (void*)code);
+    dump_hex(code, 128);
+
+    /* Now run the test */
+    {
+        size_t (*proc)(size_t, float) = (size_t (*)(size_t, float))code;
+        size_t source1_ul = 233;
+        float source2_f = -9.0f;
+        size_t expected_result = (size_t)(source1_ul + source2_f);
+        size_t result = proc(source1_ul, source2_f);
+
+        printf("Result: %zu (expected: %zu)\n", result, expected_result);
+        if (result == expected_result) {
+            printf("PASSED!\n");
+        } else {
+            printf("FAILED!\n");
+        }
+    }
+
+    dill_free_handle(h);
+    dill_free_stream(s);
+
+    return 0;
+}

--- a/x86_64_rt.c
+++ b/x86_64_rt.c
@@ -24,8 +24,8 @@ dill_x86_64_hidden_ULtoD(size_t a)
 extern size_t
 dill_x86_64_hidden_DtoUL(double a)
 {
-    size_t l = (long)a;
-    return l;
+    /* Cast directly to size_t, not via long (long is 32-bit on Windows) */
+    return (size_t)a;
 }
 
 static xfer_entry x86_64_xfer_recs[5] = {


### PR DESCRIPTION
- virtual.c: Use sizeof(uintptr_t) instead of sizeof(long) in is_convert_noop() to correctly handle platforms where long is 32-bit but pointers are 64-bit (Windows x64)
- x86_64.c: Add proper unsigned-to-float conversions for DILL_U and DILL_US types by zero-extending to 64-bit before cvtsi2ss/cvtsi2sd
- x86_64_rt.c: Fix DtoUL helper to cast directly to size_t instead of going through long (which truncates on Windows where long is 32-bit)
- vtests/mixed_params.c: Add test for mixed integer/float parameter passing which exercises the Windows x64 calling convention