### PR TITLE
Add 32-bit Windows build to CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -80,12 +80,15 @@ jobs:
         jobname: [
           windows2022-vs2022-clang,
           windows2025-vs2022-msvc,
+          windows2022-vs2022-msvc-win32,
           macos-clang ]
         include:
         - jobname: windows2022-vs2022-clang
           vm: windows-2022
         - jobname: windows2025-vs2022-msvc
           vm: windows-2025
+        - jobname: windows2022-vs2022-msvc-win32
+          vm: windows-2022
         - jobname: macos-clang
           vm: macos-latest
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 # The directory label is used for CDash to treat DILL as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS DILL)
 
-project(DILL VERSION 3.1.4 LANGUAGES C CXX)
+project(DILL VERSION 3.2.0 LANGUAGES C CXX)
 
 # Some boilerplate to setup nice output directories
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
 
-# CI cache bust: 2026-01-23
 # The directory label is used for CDash to treat DILL as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS DILL)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
+# CI cache bust: 2026-01-23
 # The directory label is used for CDash to treat DILL as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS DILL)
 

--- a/dill_util.c
+++ b/dill_util.c
@@ -368,6 +368,7 @@ dill_create_stream()
     s = dill_cross_init(NATIVE_ARCH);
     s->p->native_mach_reset = s->p->mach_reset;
     s->p->native.code_base = s->p->code_base;
+    s->p->native.code_limit = s->p->code_limit;
     s->p->native.mach_info = s->p->mach_info;
     s->p->mach_reset = dill_virtual_init;
     init_code_block(s);

--- a/ia64.c
+++ b/ia64.c
@@ -1964,8 +1964,7 @@ ia64_reg_init(dill_stream s)
 }
 
 extern void*
-gen_ia64_mach_info(s)
-dill_stream s;
+gen_ia64_mach_info(dill_stream s)
 {
     ia64_mach_info smi = malloc(sizeof(*smi));
     if (s->p->mach_info != NULL) {

--- a/ia64.h
+++ b/ia64.h
@@ -57,7 +57,7 @@ typedef struct ia64_mach_info {
 
 extern int ia64_type_align[];
 extern int ia64_type_size[];
-extern void *gen_ia64_mach_info();
+extern void *gen_ia64_mach_info(dill_stream c);
 extern void ia64_arith3(dill_stream c, int op, int commut, int dest, int src1, int src2);
 extern void ia64_arith2(dill_stream c, int op, int subop, int dest, int src);
 extern void ia64_bswap(dill_stream c, int op, int subop, int dest, int src);

--- a/pregen-source/dill_virtual.c
+++ b/pregen-source/dill_virtual.c
@@ -293,11 +293,11 @@ extern int virtual_callr(dill_stream s, int type, int src)
     virtual_insn i;
     i.class_code = iclass_call;
     i.insn_code = 0x10 | type;
-    i.opnds.bri.src = -1;
-    if (type != DILL_V) i.opnds.bri.src = dill_getreg(s, type);
-    i.opnds.bri.imm_l = src;
+    i.opnds.calli.src = -1;
+    if (type != DILL_V) i.opnds.calli.src = dill_getreg(s, type);
+    i.opnds.calli.imm_l = src;
     INSN_OUT(s, i);
-    return i.opnds.bri.src;
+    return i.opnds.calli.src;
 }
 
 extern void virtual_push(dill_stream s, int type, int reg)

--- a/pregen-source/tests/regress.c
+++ b/pregen-source/tests/regress.c
@@ -47,6 +47,8 @@ int main(int argc, char *argv[])
     int 	aligned_offset, unaligned_offset;
     int 	shifti, shiftu, shiftl, shiftul;
 
+    (void)df; (void)dd;  /* may be unused if float tests disabled */
+
     for (i=1; i < argc; i++) {
 	if (strcmp(argv[i], "-v") == 0) {
 	    verbose++;

--- a/pregen-source/tests/regress_max_arg_4.c
+++ b/pregen-source/tests/regress_max_arg_4.c
@@ -47,6 +47,8 @@ int main(int argc, char *argv[])
     int 	aligned_offset, unaligned_offset;
     int 	shifti, shiftu, shiftl, shiftul;
 
+    (void)df; (void)dd;  /* may be unused if float tests disabled */
+
     for (i=1; i < argc; i++) {
 	if (strcmp(argv[i], "-v") == 0) {
 	    verbose++;

--- a/pregen-source/tests/regress_no_float__max_arg_2.c
+++ b/pregen-source/tests/regress_no_float__max_arg_2.c
@@ -47,6 +47,8 @@ int main(int argc, char *argv[])
     int 	aligned_offset, unaligned_offset;
     int 	shifti, shiftu, shiftl, shiftul;
 
+    (void)df; (void)dd;  /* may be unused if float tests disabled */
+
     for (i=1; i < argc; i++) {
 	if (strcmp(argv[i], "-v") == 0) {
 	    verbose++;

--- a/scripts/ci/cmake/windows2022-vs2022-msvc-win32.cmake
+++ b/scripts/ci/cmake/windows2022-vs2022-msvc-win32.cmake
@@ -1,0 +1,7 @@
+# Client maintainer: eisen@cc.gatech.edu
+
+set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
+set(CTEST_CMAKE_GENERATOR_PLATFORM Win32)
+
+list(APPEND CTEST_UPDATE_NOTES_FILES "${CMAKE_CURRENT_LIST_FILE}")
+include(${CMAKE_CURRENT_LIST_DIR}/windows-common.cmake)

--- a/tests/test-gen
+++ b/tests/test-gen
@@ -910,6 +910,8 @@ int main(int argc, char *argv[])
     int 	aligned_offset, unaligned_offset;
     int 	shifti, shiftu, shiftl, shiftul;
 
+    (void)df; (void)dd;  /* may be unused if float tests disabled */
+
     for (i=1; i < argc; i++) {
 	if (strcmp(argv[i], "-v") == 0) {
 	    verbose++;

--- a/virtual.c
+++ b/virtual.c
@@ -1243,7 +1243,7 @@ build_bbs(dill_stream c, void* vinsns, void* prefix_begin, void* code_end)
     bb->is_loop_start = 0;
     bb->is_loop_end = 0;
     if (prefix_begin < code_end) {
-        i = ((char*)prefix_begin - (char*)insns) / sizeof(virtual_insn);
+        i = (int)(((char*)prefix_begin - (char*)insns) / sizeof(virtual_insn));
         bb->start = i;
         while ((insn = &insns[i++]) < (virtual_insn*)code_end) {
             build_bb_body(c, insn, (int)i, insns);

--- a/virtual.c
+++ b/virtual.c
@@ -1231,7 +1231,7 @@ build_bbs(dill_stream c, void* vinsns, void* prefix_begin, void* code_end)
 
     vmi->bbcount = 0;
     vmi->bblist = malloc(sizeof(struct basic_block));
-    size_t i = 0;
+    int i = 0;
     bb = vmi->bblist;
     bb->start = 0;
     bb->label = -1;

--- a/virtual.ops
+++ b/virtual.ops
@@ -578,11 +578,11 @@ extern int virtual_callr(dill_stream s, int type, int src)
     virtual_insn i;
     i.class_code = iclass_call;
     i.insn_code = 0x10 | type;
-    i.opnds.bri.src = -1;
-    if (type != DILL_V) i.opnds.bri.src = dill_getreg(s, type);
-    i.opnds.bri.imm_l = src;
+    i.opnds.calli.src = -1;
+    if (type != DILL_V) i.opnds.calli.src = dill_getreg(s, type);
+    i.opnds.calli.imm_l = src;
     INSN_OUT(s, i);
-    return i.opnds.bri.src;
+    return i.opnds.calli.src;
 }
 
 extern void virtual_push(dill_stream s, int type, int reg)

--- a/x86.c
+++ b/x86.c
@@ -2045,7 +2045,7 @@ x86_setf(dill_stream s, int type, int junk, int dest, double imm)
 
     if (smi->generate_SSE) {
 	if (type == DILL_F) {
-	    a.f = imm;
+	    a.f = (float)imm;
 	    x86_seti(s, EAX, a.i);
 	    BYTE_OUT4(s, 0x66, 0x0f, 0x6e, ModRM(0x3, dest, EAX));
 	} else {

--- a/x86.c
+++ b/x86.c
@@ -247,7 +247,7 @@ generate_prefix_code(dill_stream s, int force, int ar_size )
     for (i = 0; i < s->p->c_param_count; i++) {
 	if (args[i].is_register) {
 	    if ((args[i].type != DILL_F) && (args[i].type != DILL_D)) {
-		x86_ploadi(s, DILL_I, 0, args[i].in_reg, EBP, args[i].offset);
+		x86_ploadi(s, args[i].type, 0, args[i].in_reg, EBP, args[i].offset);
 	    } else {
 		if (smi->generate_SSE) {
 		    x86_ploadi(s, args[i].type, 0, args[i].in_reg, EBP, args[i].offset);
@@ -457,11 +457,11 @@ x86_ploadi(dill_stream s, int type, int force_8087, int dest, int src, long offs
     switch(type){
     case DILL_C:
 	x86_lshi(s, dest, tmp_dest, 24);
-	x86_rshi(s, dest, dest, 24);
+	x86_rshai(s, dest, dest, 24);
 	break;
     case DILL_S:
 	x86_lshi(s, dest, tmp_dest, 16);
-	x86_rshi(s, dest, dest, 16);
+	x86_rshai(s, dest, dest, 16);
 	break;
     case DILL_UC: case DILL_US:
 	if (dest != tmp_dest)
@@ -538,11 +538,11 @@ x86_sse_ploadi(dill_stream s, int type, int junk, int dest, int src, long offset
     switch(type){
     case DILL_C:
 	x86_lshi(s, dest, tmp_dest, 24);
-	x86_rshi(s, dest, dest, 24);
+	x86_rshai(s, dest, dest, 24);
 	break;
     case DILL_S:
 	x86_lshi(s, dest, tmp_dest, 16);
-	x86_rshi(s, dest, dest, 16);
+	x86_rshai(s, dest, dest, 16);
 	break;
     case DILL_UC: case DILL_US:
 	if (dest != tmp_dest)
@@ -628,11 +628,11 @@ x86_pload(dill_stream s, int type, int force_8087, int dest, int src1, int src2)
     switch(type){
     case DILL_C:
 	x86_lshi(s, dest, tmp_dest, 24);
-	x86_rshi(s, dest, dest, 24);
+	x86_rshai(s, dest, dest, 24);
 	break;
     case DILL_S:
 	x86_lshi(s, dest, tmp_dest, 16);
-	x86_rshi(s, dest, dest, 16);
+	x86_rshai(s, dest, dest, 16);
 	break;
     case DILL_UC: case DILL_US:
 	if (dest != tmp_dest)

--- a/x86.c
+++ b/x86.c
@@ -2105,8 +2105,7 @@ x86_reg_init(dill_stream s, x86_mach_info smi)
 #define bit_sse (1<<25)
 
 extern void*
-gen_x86_mach_info(s)
-dill_stream s;
+gen_x86_mach_info(dill_stream s)
 {
     static int host_supports_SSE = -1;
     x86_mach_info smi = malloc(sizeof(*smi));
@@ -2230,7 +2229,7 @@ x86_print_insn(dill_stream s, void *info_ptr, void *insn)
 #endif
 }
 
-extern void null_func(){}
+extern void null_func(void){}
 extern int
 x86_count_insn(dill_stream s, int start, int end)
 {

--- a/x86.h
+++ b/x86.h
@@ -216,7 +216,7 @@ typedef struct x86_mach_info {
 
 extern int x86_type_align[];
 extern int x86_type_size[];
-extern void *gen_x86_mach_info();
+extern void *gen_x86_mach_info(dill_stream s);
 extern void x86_arith3(dill_stream s, int op, int commut, int dest, int src1, int src2);
 extern void x86_arith2(dill_stream s, int op, int subop, int dest, int src);
 extern void x86_mul(dill_stream s, int signed, int imm, int dest, int src1, int src2);

--- a/x86_64_rt.c
+++ b/x86_64_rt.c
@@ -48,6 +48,7 @@ x86_64_rt_call_link(char* code, call_t* t)
     }
 }
 
+#if !defined(USE_VIRTUAL_PROTECT)
 static void
 x86_64_flush(void* base, void* limit)
 {
@@ -76,6 +77,7 @@ x86_64_flush(void* base, void* limit)
     }
 #endif
 }
+#endif
 
 extern char*
 x86_64_package_stitch(char* code, call_t* t, dill_pkg pkg)

--- a/x86_64_rt.c
+++ b/x86_64_rt.c
@@ -48,11 +48,12 @@ x86_64_rt_call_link(char* code, call_t* t)
     }
 }
 
-#if !defined(USE_VIRTUAL_PROTECT)
 static void
 x86_64_flush(void* base, void* limit)
 {
-#if defined(HOST_X86_64)
+#if defined(USE_VIRTUAL_PROTECT)
+    FlushInstructionCache(GetCurrentProcess(), base, (char*)limit - (char*)base);
+#elif defined(HOST_X86_64)
     {
         volatile void* ptr = base;
 
@@ -77,7 +78,6 @@ x86_64_flush(void* base, void* limit)
     }
 #endif
 }
-#endif
 
 extern char*
 x86_64_package_stitch(char* code, call_t* t, dill_pkg pkg)
@@ -115,7 +115,7 @@ x86_64_package_stitch(char* code, call_t* t, dill_pkg pkg)
                     GetLastError(), (void*)tmp, pkg->code_size);
             return NULL;
         }
-        FlushInstructionCache(GetCurrentProcess(), tmp, pkg->code_size);
+        x86_64_flush(tmp, tmp + pkg->code_size);
     }
 #else
     x86_64_flush(code, code + pkg->code_size);

--- a/x86_64_rt.c
+++ b/x86_64_rt.c
@@ -83,7 +83,6 @@ x86_64_package_stitch(char* code, call_t* t, dill_pkg pkg)
     char* tmp = code;
     dill_lookup_xfer_addrs(t, &x86_64_xfer_recs[0]);
     x86_64_rt_call_link(code, t);
-    x86_64_flush(code, code + 1024);
 #ifdef USE_MACOS_MAP_JIT
 #ifndef MAP_ANONYMOUS
 #define MAP_ANONYMOUS MAP_ANON
@@ -105,8 +104,8 @@ x86_64_package_stitch(char* code, call_t* t, dill_pkg pkg)
     tmp = (void*)mmap(0, pkg->code_size, PROT_EXEC | PROT_READ | PROT_WRITE,
                       MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
     memcpy(tmp, code, pkg->code_size);
-#endif
-#ifdef USE_VIRTUAL_PROTECT
+    x86_64_flush(tmp, tmp + pkg->code_size);
+#elif defined(USE_VIRTUAL_PROTECT)
     {
         DWORD dummy;
         if (!VirtualProtect(tmp, pkg->code_size, PAGE_EXECUTE_READWRITE, &dummy)) {
@@ -114,7 +113,10 @@ x86_64_package_stitch(char* code, call_t* t, dill_pkg pkg)
                     GetLastError(), (void*)tmp, pkg->code_size);
             return NULL;
         }
+        FlushInstructionCache(GetCurrentProcess(), tmp, pkg->code_size);
     }
+#else
+    x86_64_flush(code, code + pkg->code_size);
 #endif
     return tmp + pkg->entry_offset;
 }

--- a/x86_rt.c
+++ b/x86_rt.c
@@ -59,6 +59,7 @@ x86_package_stitch(char *code, call_t *t, dill_pkg pkg)
                     GetLastError(), (void*)tmp, pkg->code_size);
             return NULL;
         }
+        FlushInstructionCache(GetCurrentProcess(), tmp, pkg->code_size);
     }
 #endif
     return tmp + pkg->entry_offset;

--- a/x86_rt.c
+++ b/x86_rt.c
@@ -1,12 +1,16 @@
 #include "config.h"
+#include <stdio.h>
 #ifdef USE_MMAP_CODE_SEG
 #include <sys/mman.h>
+#endif
+#ifdef USE_VIRTUAL_PROTECT
+#include <windows.h>
+#include <memoryapi.h>
 #endif
 #include <string.h>
 #include "dill.h"
 #include "dill_internal.h"
 #include "x86.h"
-#include <string.h>
 
 extern long dill_x86_hidden_mod(long a, long b)
 { return a % b; }
@@ -43,9 +47,19 @@ x86_package_stitch(char *code, call_t *t, dill_pkg pkg)
 #define MAP_ANONYMOUS MAP_ANON
 #endif
     tmp = (void*)mmap(0, pkg->code_size,
-		      PROT_EXEC | PROT_READ | PROT_WRITE, 
+		      PROT_EXEC | PROT_READ | PROT_WRITE,
 		      MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
     memcpy(tmp, code, pkg->code_size);
+#endif
+#ifdef USE_VIRTUAL_PROTECT
+    {
+        DWORD dummy;
+        if (!VirtualProtect(tmp, pkg->code_size, PAGE_EXECUTE_READWRITE, &dummy)) {
+            fprintf(stderr, "VirtualProtect failed with error %lu for address %p, size %d\n",
+                    GetLastError(), (void*)tmp, pkg->code_size);
+            return NULL;
+        }
+    }
 #endif
     return tmp + pkg->entry_offset;
 }


### PR DESCRIPTION
- Add windows2022-vs2022-msvc-win32 job to build matrix
- Create cmake config with Win32 platform target
- Fix uninitialized native.code_limit in dill_create_stream
- Add VirtualProtect to x86 package_stitch and stest
- Fix virtual_callr using wrong union member for indirect calls
- Fix x86 signed char/short comparison failures (use arithmetic shift)
- Fix x86 parameter loading to use actual type for sign extension
- Use FlushInstructionCache on Windows in x86_64_flush
- Add FlushInstructionCache to x86_rt for 32-bit Windows