### PR TITLE
Fix macOS MAP_JIT support in stest and arm64_clone_code

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,7 +1,7 @@
 set(CTEST_PROJECT_NAME "GTKorvo")
 set(CTEST_NIGHTLY_START_TIME "01:00:00 UTC")
 
-set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_METHOD "https")
 set(CTEST_DROP_SITE "open.cdash.org")
 set(CTEST_DROP_LOCATION "/submit.php?project=GTKorvo")
 set(CTEST_DROP_SITE_CDASH TRUE)

--- a/arm64.c
+++ b/arm64.c
@@ -124,13 +124,42 @@ arm64_simple_ret(dill_stream s)
     dill_mark_ret_location(s);
     /* Emit frame teardown epilogue:
      * mov sp, x29               ; Restore SP to frame pointer (deallocate save area)
-     * ldp x29, x30, [sp], #16   ; Restore FP and LR, post-increment SP
+     * ldp x29, x30, [sp], #16   ; Restore FP and LR
+     * ldp d14, d15, [sp], #16   ; Restore float callee-saved regs
+     * ldp d12, d13, [sp], #16
+     * ldp d10, d11, [sp], #16
+     * ldp d8, d9, [sp], #16
+     * ldp x27, x28, [sp], #16   ; Restore integer callee-saved regs
+     * ldp x25, x26, [sp], #16
+     * ldp x23, x24, [sp], #16
+     * ldp x21, x22, [sp], #16
+     * ldp x19, x20, [sp], #16
      * ret
      */
     /* MOV sp, x29 (ADD sp, x29, #0) = 0x910003BF */
     INSN_OUT(s, 0x910003BF);
     /* LDP x29, x30, [sp], #16 = 0xA8C17BFD */
     INSN_OUT(s, 0xA8C17BFD);
+    /* Restore float callee-saved registers d8-d15 */
+    /* LDP d14, d15, [sp], #16 = 0x6CC13FEE */
+    INSN_OUT(s, 0x6CC13FEE);
+    /* LDP d12, d13, [sp], #16 = 0x6CC137EC */
+    INSN_OUT(s, 0x6CC137EC);
+    /* LDP d10, d11, [sp], #16 = 0x6CC12FEA */
+    INSN_OUT(s, 0x6CC12FEA);
+    /* LDP d8, d9, [sp], #16 = 0x6CC127E8 */
+    INSN_OUT(s, 0x6CC127E8);
+    /* Restore integer callee-saved registers x19-x28 */
+    /* LDP x27, x28, [sp], #16 = 0xA8C173FB */
+    INSN_OUT(s, 0xA8C173FB);
+    /* LDP x25, x26, [sp], #16 = 0xA8C16BF9 */
+    INSN_OUT(s, 0xA8C16BF9);
+    /* LDP x23, x24, [sp], #16 = 0xA8C163F7 */
+    INSN_OUT(s, 0xA8C163F7);
+    /* LDP x21, x22, [sp], #16 = 0xA8C15BF5 */
+    INSN_OUT(s, 0xA8C15BF5);
+    /* LDP x19, x20, [sp], #16 = 0xA8C153F3 */
+    INSN_OUT(s, 0xA8C153F3);
     arm64_ret_insn(s);
     arm64_nop(s);  /* nops for potential epilogue patching */
     arm64_nop(s);
@@ -401,18 +430,58 @@ arm64_proc_start(dill_stream s, char *subr_name, int arg_count,
     s->p->fp = s->p->cur_ip;
 
     /* Emit frame setup prologue:
-     * stp x29, x30, [sp, #-16]!   ; Save FP and LR, pre-decrement SP
-     * mov x29, sp                  ; Set up frame pointer
-     * sub sp, sp, #224            ; Allocate save area (224 bytes, 16-byte aligned)
+     * First save callee-saved registers (x19-x28, d8-d15), then FP/LR:
+     * stp x19, x20, [sp, #-16]!  ; Save integer callee-saved regs (80 bytes)
+     * stp x21, x22, [sp, #-16]!
+     * stp x23, x24, [sp, #-16]!
+     * stp x25, x26, [sp, #-16]!
+     * stp x27, x28, [sp, #-16]!
+     * stp d8, d9, [sp, #-16]!    ; Save float callee-saved regs (64 bytes)
+     * stp d10, d11, [sp, #-16]!
+     * stp d12, d13, [sp, #-16]!
+     * stp d14, d15, [sp, #-16]!
+     * stp x29, x30, [sp, #-16]!  ; Save FP and LR
+     * mov x29, sp                 ; Set up frame pointer
+     * sub sp, sp, #224           ; Allocate save area
      *
-     * Stack layout after prologue:
-     * [FP + 8]  = saved x30 (LR)
-     * [FP + 0]  = saved x29 (old FP)
+     * Stack layout after prologue (offsets from FP):
+     * [FP + 160] = caller's stack (incoming stack args start here)
+     * [FP + 144] = saved x19/x20
+     * [FP + 128] = saved x21/x22
+     * [FP + 112] = saved x23/x24
+     * [FP + 96]  = saved x25/x26
+     * [FP + 80]  = saved x27/x28
+     * [FP + 64]  = saved d8/d9
+     * [FP + 48]  = saved d10/d11
+     * [FP + 32]  = saved d12/d13
+     * [FP + 16]  = saved d14/d15
+     * [FP + 8]   = saved x30 (LR)
+     * [FP + 0]   = saved x29 (old FP)
      * [FP - 16] to [FP - 80]   = integer arg reg save area (x0-x7)
      * [FP - 96] to [FP - 152]  = integer tmp reg save area (x9-x15)
      * [FP - 160] to [FP - 224] = float reg save area (v0-v7)
      * [SP] = bottom of save area (FP - 224)
      */
+    /* Save callee-saved integer registers x19-x28 */
+    /* STP x19, x20, [sp, #-16]! = 0xA9BF53F3 */
+    INSN_OUT(s, 0xA9BF53F3);
+    /* STP x21, x22, [sp, #-16]! = 0xA9BF5BF5 */
+    INSN_OUT(s, 0xA9BF5BF5);
+    /* STP x23, x24, [sp, #-16]! = 0xA9BF63F7 */
+    INSN_OUT(s, 0xA9BF63F7);
+    /* STP x25, x26, [sp, #-16]! = 0xA9BF6BF9 */
+    INSN_OUT(s, 0xA9BF6BF9);
+    /* STP x27, x28, [sp, #-16]! = 0xA9BF73FB */
+    INSN_OUT(s, 0xA9BF73FB);
+    /* Save callee-saved float registers d8-d15 (lower 64 bits of v8-v15) */
+    /* STP d8, d9, [sp, #-16]! = 0x6DBF27E8 */
+    INSN_OUT(s, 0x6DBF27E8);
+    /* STP d10, d11, [sp, #-16]! = 0x6DBF2FEA */
+    INSN_OUT(s, 0x6DBF2FEA);
+    /* STP d12, d13, [sp, #-16]! = 0x6DBF37EC */
+    INSN_OUT(s, 0x6DBF37EC);
+    /* STP d14, d15, [sp, #-16]! = 0x6DBF3FEE */
+    INSN_OUT(s, 0x6DBF3FEE);
     /* STP x29, x30, [sp, #-16]! = 0xA9BF7BFD */
     INSN_OUT(s, 0xA9BF7BFD);
     /* MOV x29, sp (ADD x29, sp, #0) = 0x910003FD */
@@ -513,10 +582,10 @@ arm64_proc_start(dill_stream s, char *subr_name, int arg_count,
 		if (arglist != NULL) arglist[i] = -1;
 		continue;
 	    }
-	    /* Load from stack: incoming stack args are at [FP + 16 + offset]
-	     * (+16 accounts for saved FP and LR in the frame setup)
+	    /* Load from stack: incoming stack args are at [FP + 160 + offset]
+	     * (+16 for FP/LR, +64 for d8-d15, +80 for x19-x28)
 	     */
-	    arm64_ploadi(s, type, 0, tmp_reg, _fp, args[i].offset + 16);
+	    arm64_ploadi(s, type, 0, tmp_reg, _fp, args[i].offset + 160);
 	    args[i].in_reg = tmp_reg;
 	    args[i].out_reg = tmp_reg;
 	    args[i].is_register = 1;
@@ -1220,6 +1289,7 @@ arm64_local_op(dill_stream s, int flag, int val)
 #define GP_ARG_SAVE_OFFSET 16      /* x0-x7 save area starts at FP-16 */
 #define GP_TMP_SAVE_OFFSET 96      /* x9-x15 save area starts at FP-96 */
 #define FP_SAVE_AREA_OFFSET 160    /* v0-v7 save area starts at FP-160 */
+#define CALLEE_SAVE_OFFSET 80      /* x19-x28 saved above FP (5 pairs * 16 bytes) */
 
 void
 arm64_save_restore_op(dill_stream s, int save_restore, int type, int reg)

--- a/dill_cplus.c
+++ b/dill_cplus.c
@@ -14,7 +14,12 @@ extern void*
 get_this_ptr(method_pointer m, void* object_ptr)
 {
     void* th;
+#if defined(HOST_ARM64)
+    /* On ARM64, delta's low bit indicates virtual, so mask it off for adjustment */
+    th = ((char*)object_ptr) + (m->delta >> 1);
+#else
     th = ((char*)object_ptr) + (m->delta / 2);
+#endif
     return th;
 }
 
@@ -25,12 +30,17 @@ get_xfer_ptr(method_pointer m, void* object_ptr)
     cptr = m->u.call_ptr;
 #if defined(NOTDEF)
     if (m->vflag != 0) { /* vflag indicates virtual on some archs*/
-#elif defined(HOST_ARM6) || defined(HOST_ARM7)
-    if ((m->delta & 0x1) == 1) { /* odd delta indicates virtual on some archs*/
+#elif defined(HOST_ARM6) || defined(HOST_ARM7) || defined(HOST_ARM64)
+    if ((m->delta & 0x1) == 1) { /* odd delta indicates virtual on ARM */
 #else
     if ((m->u.vtindex & 0x1) == 1) { /* METHOD_PTR IS ODD - virtual */
 #endif
+#if defined(HOST_ARM64)
+        /* On ARM64, vtindex is a byte offset into vtable (no adjustment needed) */
+        long vtableindex = m->u.vtindex;
+#else
         int vtableindex = m->u.vtindex & -4;
+#endif
         void** vtable = *((void***)object_ptr);
 
         vtable = (void**)(((char*)vtable) + vtableindex);

--- a/scripts/dashboard/dill_common.cmake
+++ b/scripts/dashboard/dill_common.cmake
@@ -62,8 +62,12 @@
 #   set(ENV{FC}  /path/to/fc)   # Fortran compiler (optional)
 #   set(ENV{LD_LIBRARY_PATH} /path/to/vendor/lib) # (if necessary)
 
-set(CTEST_PROJECT_NAME "DILL")
+set(CTEST_PROJECT_NAME "GTKorvo")
+set(CTEST_DROP_METHOD "https")
 set(CTEST_DROP_SITE "open.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=GTKorvo")
+set(CTEST_DROP_SITE_CDASH TRUE)
+set(CTEST_LABELS_FOR_SUBPROJECTS DILL)
 if(NOT dashboard_git_url)
   set(dashboard_git_url "https://github.com/GTkorvo/dill.git")
 endif()

--- a/tests/stest.c
+++ b/tests/stest.c
@@ -17,6 +17,16 @@
 #ifdef USE_MMAP_CODE_SEG
 #include "sys/mman.h"
 #endif
+#ifdef USE_MACOS_MAP_JIT
+#include <sys/mman.h>
+#include <pthread.h>
+#endif
+
+#ifdef USE_MACOS_MAP_JIT
+#define WRITE_PROTECT(x)    pthread_jit_write_protect_np(x)
+#else
+#define WRITE_PROTECT(x)
+#endif
 
 dill_exec_handle mk_test(dill_stream s) {
 	int i, regs, fregs;
@@ -116,9 +126,12 @@ int main() {
 		dill_dump(s);
 		printf("failure at point %d (second)\n", ret);
 	}
-#ifdef USE_MMAP_CODE_SEG
+#if defined(USE_MMAP_CODE_SEG) || defined(USE_MACOS_MAP_JIT)
 #ifndef MAP_ANONYMOUS
 #define MAP_ANONYMOUS MAP_ANON
+#endif
+#ifndef MAP_JIT
+#define MAP_JIT 0
 #endif
 	{
 	    int size = dill_code_size(s);
@@ -127,9 +140,9 @@ int main() {
 	        ps = (getpagesize ());
 	    }
 	    if (ps > size) size = ps;
-	    target = (void*)mmap(0, size, 
-				 PROT_EXEC | PROT_READ | PROT_WRITE, 
-				 MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+	    target = (void*)mmap(0, size,
+				 PROT_EXEC | PROT_READ | PROT_WRITE,
+				 MAP_ANONYMOUS|MAP_PRIVATE|MAP_JIT, -1, 0);
 	}
 	if (target == (void*)-1) perror("mmap");
 #else
@@ -139,7 +152,9 @@ int main() {
 	    return 1;
 	}
 #endif
+	WRITE_PROTECT(0);
 	ip = (int (*)()) dill_clone_code(s, target, dill_code_size(s));
+	WRITE_PROTECT(1);
 	dill_free_stream(s);
 	ret = ip();
 	if(ret == 0)


### PR DESCRIPTION
- tests/stest.c: Add proper MAP_JIT support for macOS
- implement arm64_clone_code
