### PR TITLE
Add VirtualProtect diagnostics and fix CDash submission

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,7 +1,7 @@
 set(CTEST_PROJECT_NAME "GTKorvo")
 set(CTEST_NIGHTLY_START_TIME "01:00:00 UTC")
 
-set(CTEST_DROP_METHOD "https")
+set(CTEST_DROP_METHOD "http")
 set(CTEST_DROP_SITE "open.cdash.org")
 set(CTEST_DROP_LOCATION "/submit.php?project=GTKorvo")
 set(CTEST_DROP_SITE_CDASH TRUE)

--- a/scripts/dashboard/dill_common.cmake
+++ b/scripts/dashboard/dill_common.cmake
@@ -63,7 +63,7 @@
 #   set(ENV{LD_LIBRARY_PATH} /path/to/vendor/lib) # (if necessary)
 
 set(CTEST_PROJECT_NAME "GTKorvo")
-set(CTEST_DROP_METHOD "https")
+set(CTEST_DROP_METHOD "http")
 set(CTEST_DROP_SITE "open.cdash.org")
 set(CTEST_DROP_LOCATION "/submit.php?project=GTKorvo")
 set(CTEST_DROP_SITE_CDASH TRUE)

--- a/x86_64.c
+++ b/x86_64.c
@@ -3122,11 +3122,14 @@ x86_64_flush(void* base, void* limit)
     }
 #endif
 #ifdef USE_VIRTUAL_PROTECT
-    int result;
-    DWORD dummy;
-    size_t size = ((intptr_t)limit - (intptr_t)base);
-    result = VirtualProtect(base, size, PAGE_EXECUTE_READWRITE, &dummy);
-    (void) result;
+    {
+        DWORD dummy;
+        size_t size = ((intptr_t)limit - (intptr_t)base);
+        if (!VirtualProtect(base, size, PAGE_EXECUTE_READWRITE, &dummy)) {
+            fprintf(stderr, "VirtualProtect failed with error %lu for address %p, size %zu\n",
+                    GetLastError(), base, size);
+        }
+    }
 #endif
 }
 extern void

--- a/x86_64_rt.c
+++ b/x86_64_rt.c
@@ -107,11 +107,14 @@ x86_64_package_stitch(char* code, call_t* t, dill_pkg pkg)
     memcpy(tmp, code, pkg->code_size);
 #endif
 #ifdef USE_VIRTUAL_PROTECT
-    int result;
-    DWORD dummy;
-    result =
-        VirtualProtect(tmp, pkg->code_size, PAGE_EXECUTE_READWRITE, &dummy);
-    (void) result;
+    {
+        DWORD dummy;
+        if (!VirtualProtect(tmp, pkg->code_size, PAGE_EXECUTE_READWRITE, &dummy)) {
+            fprintf(stderr, "VirtualProtect failed with error %lu for address %p, size %d\n",
+                    GetLastError(), (void*)tmp, pkg->code_size);
+            return NULL;
+        }
+    }
 #endif
     return tmp + pkg->entry_offset;
 }


### PR DESCRIPTION
- Add error checking and diagnostic output for VirtualProtect calls on Windows
- Fix CDash submission by using HTTP instead of HTTPS