### PR TITLE
Split general.c into separate functions for faster compilation

### DIFF
--- a/pregen-source/vtests/general.c
+++ b/pregen-source/vtests/general.c
@@ -14,194 +14,81 @@
 #define srand48(s) srand(s)
 #define drand48() (rand()*(1./RAND_MAX))
 #define lrand48() ((long long)rand() << 32 | rand())
-#define kill(x,y) 
+#define kill(x,y)
 #else
 extern double drand48();
 extern IMM_TYPE lrand48();
 void srand48(IMM_TYPE seedval);
 #endif
 
-int
-main(int argc, char **argv)
+/* Global test data - initialized in main() */
+static int verbose;
+static float rand1_f;
+static float rand2_f;
+static float src1f_vals[2];
+static float src2f_vals[2];
+static float br_srcf_vals[6];
+static short rand1_s;
+static short rand2_s;
+static short src1s_vals[2];
+static short src2s_vals[2];
+static short br_srcs_vals[6];
+static IMM_TYPE rand1_l;
+static IMM_TYPE rand2_l;
+static IMM_TYPE src1l_vals[2];
+static IMM_TYPE src2l_vals[2];
+static IMM_TYPE br_srcl_vals[6];
+static unsigned char rand1_uc;
+static unsigned char rand2_uc;
+static unsigned char src1uc_vals[2];
+static unsigned char src2uc_vals[2];
+static unsigned char br_srcuc_vals[6];
+static unsigned short rand1_us;
+static unsigned short rand2_us;
+static unsigned short src1us_vals[2];
+static unsigned short src2us_vals[2];
+static unsigned short br_srcus_vals[6];
+static UIMM_TYPE rand1_ul;
+static UIMM_TYPE rand2_ul;
+static UIMM_TYPE src1ul_vals[2];
+static UIMM_TYPE src2ul_vals[2];
+static UIMM_TYPE br_srcul_vals[6];
+static signed char rand1_c;
+static signed char rand2_c;
+static signed char src1c_vals[2];
+static signed char src2c_vals[2];
+static signed char br_srcc_vals[6];
+static double rand1_d;
+static double rand2_d;
+static double src1d_vals[2];
+static double src2d_vals[2];
+static double br_srcd_vals[6];
+static unsigned int rand1_u;
+static unsigned int rand2_u;
+static unsigned int src1u_vals[2];
+static unsigned int src2u_vals[2];
+static unsigned int br_srcu_vals[6];
+static int rand1_i;
+static int rand2_i;
+static int src1i_vals[2];
+static int src2i_vals[2];
+static int br_srci_vals[6];
+static char* rand1_p;
+static char* rand2_p;
+static char* src1p_vals[2];
+static char* src2p_vals[2];
+static char* br_srcp_vals[6];
+static int sh_src2_vals[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63};
+
+static UIMM_TYPE bit_pattern_vals[] = { 0x1, 0x0,  0x2, 0x1,  0x4, 0x3,  0x8, 0x7,  0x10, 0xf,  0x20, 0x1f,  0x40, 0x3f,  0x80, 0x7f,  0x100, 0xff,  0x200, 0x1ff,  0x400, 0x3ff,  0x800, 0x7ff,  0x1000, 0xfff,  0x2000, 0x1fff,  0x4000, 0x3fff,  0x8000, 0x7fff,  0x10000, 0xffff,  0x20000, 0x1ffff,  0x40000, 0x3ffff,  0x80000, 0x7ffff,  0x100000, 0xfffff,  0x200000, 0x1fffff,  0x400000, 0x3fffff,  0x800000, 0x7fffff,  0x1000000, 0xffffff,  0x2000000, 0x1ffffff,  0x4000000, 0x3ffffff,  0x8000000, 0x7ffffff,  0x10000000, 0xfffffff,  0x20000000, 0x1fffffff,  0x40000000, 0x3fffffff,  0x80000000, 0x7fffffff,  0xffffffff};
+
+
+static int
+test_arith_int(dill_stream c)
 {
-    dill_stream c = dill_create_stream();
-    int failed = 0, verbose = 0;
+    int failed = 0;
     size_t i, j;
-    UIMM_TYPE rand1_ul = (UIMM_TYPE)lrand48();
-    UIMM_TYPE rand2_ul = (UIMM_TYPE)lrand48();
-    UIMM_TYPE src1ul_vals[2];
-    UIMM_TYPE src2ul_vals[2];
-    UIMM_TYPE br_srcul_vals[6];
-    signed char rand1_c = (signed char)lrand48();
-    signed char rand2_c = (signed char)lrand48();
-    signed char src1c_vals[2];
-    signed char src2c_vals[2];
-    signed char br_srcc_vals[6];
-    unsigned int rand1_u = (unsigned int)lrand48();
-    unsigned int rand2_u = (unsigned int)lrand48();
-    unsigned int src1u_vals[2];
-    unsigned int src2u_vals[2];
-    unsigned int br_srcu_vals[6];
-    unsigned short rand1_us = (unsigned short)lrand48();
-    unsigned short rand2_us = (unsigned short)lrand48();
-    unsigned short src1us_vals[2];
-    unsigned short src2us_vals[2];
-    unsigned short br_srcus_vals[6];
-    float rand1_f = (float)drand48();
-    float rand2_f = (float)drand48();
-    float src1f_vals[2];
-    float src2f_vals[2];
-    float br_srcf_vals[6];
-    int rand1_i = (int)lrand48();
-    int rand2_i = (int)lrand48();
-    int src1i_vals[2];
-    int src2i_vals[2];
-    int br_srci_vals[6];
-    char* rand1_p = (char*)(char *)lrand48();
-    char* rand2_p = (char*)(char *)lrand48();
-    char* src1p_vals[2];
-    char* src2p_vals[2];
-    char* br_srcp_vals[6];
-    double rand1_d = (double)drand48();
-    double rand2_d = (double)drand48();
-    double src1d_vals[2];
-    double src2d_vals[2];
-    double br_srcd_vals[6];
-    IMM_TYPE rand1_l = (IMM_TYPE)lrand48();
-    IMM_TYPE rand2_l = (IMM_TYPE)lrand48();
-    IMM_TYPE src1l_vals[2];
-    IMM_TYPE src2l_vals[2];
-    IMM_TYPE br_srcl_vals[6];
-    short rand1_s = (short)lrand48();
-    short rand2_s = (short)lrand48();
-    short src1s_vals[2];
-    short src2s_vals[2];
-    short br_srcs_vals[6];
-    unsigned char rand1_uc = (unsigned char)lrand48();
-    unsigned char rand2_uc = (unsigned char)lrand48();
-    unsigned char src1uc_vals[2];
-    unsigned char src2uc_vals[2];
-    unsigned char br_srcuc_vals[6];
-    int sh_src2_vals[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63};
-
-    UIMM_TYPE bit_pattern_vals[] = { 0x1, 0x0,  0x2, 0x1,  0x4, 0x3,  0x8, 0x7,  0x10, 0xf,  0x20, 0x1f,  0x40, 0x3f,  0x80, 0x7f,  0x100, 0xff,  0x200, 0x1ff,  0x400, 0x3ff,  0x800, 0x7ff,  0x1000, 0xfff,  0x2000, 0x1fff,  0x4000, 0x3fff,  0x8000, 0x7fff,  0x10000, 0xffff,  0x20000, 0x1ffff,  0x40000, 0x3ffff,  0x80000, 0x7ffff,  0x100000, 0xfffff,  0x200000, 0x1fffff,  0x400000, 0x3fffff,  0x800000, 0x7fffff,  0x1000000, 0xffffff,  0x2000000, 0x1ffffff,  0x4000000, 0x3ffffff,  0x8000000, 0x7ffffff,  0x10000000, 0xfffffff,  0x20000000, 0x1fffffff,  0x40000000, 0x3fffffff,  0x80000000, 0x7fffffff,  0xffffffff};
-
-    src1f_vals[0] = rand1_f;
-    src1f_vals[1] = -rand1_f;
-    src2f_vals[0] = rand2_f;
-    src2f_vals[1] = -rand2_f;
-    src1d_vals[0] = rand1_d;
-    src1d_vals[1] = -rand1_d;
-    src2d_vals[0] = rand2_d;
-    src2d_vals[1] = -rand2_d;
-    src1c_vals[0] = rand1_c;
-    src1c_vals[1] = -rand1_c;
-    src2c_vals[0] = rand2_c;
-    src2c_vals[1] = -rand2_c;
-    src1s_vals[0] = rand1_s;
-    src1s_vals[1] = -rand1_s;
-    src2s_vals[0] = rand2_s;
-    src2s_vals[1] = -rand2_s;
-    src1i_vals[0] = rand1_i;
-    src1i_vals[1] = -rand1_i;
-    src2i_vals[0] = rand2_i;
-    src2i_vals[1] = -rand2_i;
-    src1l_vals[0] = rand1_l;
-    src1l_vals[1] = -rand1_l;
-    src2l_vals[0] = rand2_l;
-    src2l_vals[1] = -rand2_l;
-    src1uc_vals[0] = (unsigned char) rand1_uc;
-    src1uc_vals[1] = (unsigned char) - (char) rand1_uc;
-    src2uc_vals[0] = (unsigned char) rand2_uc;
-    src2uc_vals[1] = (unsigned char) - (char) rand2_uc;
-    src1us_vals[0] = (unsigned short) rand1_us;
-    src1us_vals[1] = (unsigned short) - (short) rand1_us;
-    src2us_vals[0] = (unsigned short) rand2_us;
-    src2us_vals[1] = (unsigned short) - (short) rand2_us;
-    src1u_vals[0] = (unsigned int) rand1_u;
-    src1u_vals[1] = (unsigned int) - (int) rand1_u;
-    src2u_vals[0] = (unsigned int) rand2_u;
-    src2u_vals[1] = (unsigned int) - (int) rand2_u;
-    src1ul_vals[0] = (UIMM_TYPE) rand1_ul;
-    src1ul_vals[1] = (UIMM_TYPE) - (intptr_t) rand1_ul;
-    src2ul_vals[0] = (UIMM_TYPE) rand2_ul;
-    src2ul_vals[1] = (UIMM_TYPE) - (intptr_t) rand2_ul;
-    br_srcuc_vals[0] = (unsigned char) rand1_uc;
-    br_srcuc_vals[1] = (unsigned char) - (char) rand1_uc;
-    br_srcuc_vals[2] = (unsigned char) rand1_uc + 1;
-    br_srcuc_vals[3] = (unsigned char) -((char) rand1_uc) + 1;
-    br_srcuc_vals[4] = (unsigned char) rand1_uc - 1;
-    br_srcuc_vals[5] = (unsigned char) -((char) rand1_uc) - 1;
-    br_srcc_vals[0] = (signed char) rand1_c;
-    br_srcc_vals[1] = (signed char) -  rand1_c;
-    br_srcc_vals[2] = (signed char) rand1_c + 1;
-    br_srcc_vals[3] = (signed char) -( rand1_c) + 1;
-    br_srcc_vals[4] = (signed char) rand1_c - 1;
-    br_srcc_vals[5] = (signed char) -( rand1_c) - 1;
-    br_srcus_vals[0] = (unsigned short) rand1_us;
-    br_srcus_vals[1] = (unsigned short) - (short) rand1_us;
-    br_srcus_vals[2] = (unsigned short) rand1_us + 1;
-    br_srcus_vals[3] = (unsigned short) -((short) rand1_us) + 1;
-    br_srcus_vals[4] = (unsigned short) rand1_us - 1;
-    br_srcus_vals[5] = (unsigned short) -((short) rand1_us) - 1;
-    br_srcs_vals[0] = (short) rand1_s;
-    br_srcs_vals[1] = (short) -  rand1_s;
-    br_srcs_vals[2] = (short) rand1_s + 1;
-    br_srcs_vals[3] = (short) -( rand1_s) + 1;
-    br_srcs_vals[4] = (short) rand1_s - 1;
-    br_srcs_vals[5] = (short) -( rand1_s) - 1;
-    br_srci_vals[0] = (int) rand1_i;
-    br_srci_vals[1] = (int) -  rand1_i;
-    br_srci_vals[2] = (int) rand1_i + 1;
-    br_srci_vals[3] = (int) -( rand1_i) + 1;
-    br_srci_vals[4] = (int) rand1_i - 1;
-    br_srci_vals[5] = (int) -( rand1_i) - 1;
-    br_srcu_vals[0] = (unsigned int) rand1_u;
-    br_srcu_vals[1] = (unsigned int) - (int) rand1_u;
-    br_srcu_vals[2] = (unsigned int) rand1_u + 1;
-    br_srcu_vals[3] = (unsigned int) -((int) rand1_u) + 1;
-    br_srcu_vals[4] = (unsigned int) rand1_u - 1;
-    br_srcu_vals[5] = (unsigned int) -((int) rand1_u) - 1;
-    br_srcl_vals[0] = (IMM_TYPE) rand1_l;
-    br_srcl_vals[1] = (IMM_TYPE) -  rand1_l;
-    br_srcl_vals[2] = (IMM_TYPE) rand1_l + 1;
-    br_srcl_vals[3] = (IMM_TYPE) -( rand1_l) + 1;
-    br_srcl_vals[4] = (IMM_TYPE) rand1_l - 1;
-    br_srcl_vals[5] = (IMM_TYPE) -( rand1_l) - 1;
-    br_srcul_vals[0] = (UIMM_TYPE) rand1_ul;
-    br_srcul_vals[1] = (UIMM_TYPE) - (intptr_t) rand1_ul;
-    br_srcul_vals[2] = (UIMM_TYPE) rand1_ul + 1;
-    br_srcul_vals[3] = (UIMM_TYPE) -((intptr_t) rand1_ul) + 1;
-    br_srcul_vals[4] = (UIMM_TYPE) rand1_ul - 1;
-    br_srcul_vals[5] = (UIMM_TYPE) -((intptr_t) rand1_ul) - 1;
-    br_srcd_vals[0] = (double) rand1_d;
-    br_srcd_vals[1] = (double) -  rand1_d;
-    br_srcd_vals[2] = (double) rand1_d + 1;
-    br_srcd_vals[3] = (double) -( rand1_d) + 1;
-    br_srcd_vals[4] = (double) rand1_d - 1;
-    br_srcd_vals[5] = (double) -( rand1_d) - 1;
-    br_srcf_vals[0] = (float) rand1_f;
-    br_srcf_vals[1] = (float) -  rand1_f;
-    br_srcf_vals[2] = (float) rand1_f + 1;
-    br_srcf_vals[3] = (float) -( rand1_f) + 1;
-    br_srcf_vals[4] = (float) rand1_f - 1;
-    br_srcf_vals[5] = (float) -( rand1_f) - 1;
-    br_srcp_vals[0] = (char*) rand1_p;
-    br_srcp_vals[1] = (char*) rand1_p;
-    br_srcp_vals[2] = (char*) rand1_p + 1;
-    br_srcp_vals[3] = (char*) rand1_p + 1;
-    br_srcp_vals[4] = (char*) rand1_p - 1;
-    br_srcp_vals[5] = (char*) rand1_p - 1;
-    /* reference these values since they currently aren't done elsewhere */
-    src2p_vals[0] = src1p_vals[0] = rand1_p; src2p_vals[1] = src1p_vals[1] = rand2_p;
-    (void)src2d_vals[0];
-    (void)src2s_vals[0];
-    (void)src2p_vals[0];
-    (void)src2c_vals[0];
-    (void)src2uc_vals[0];
-    (void)src2us_vals[0];
-    (void)src2f_vals[0];
-    if (argc > 1) verbose++;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for dill_addi */
     if (verbose) printf("test for dill_addi");
@@ -1858,6 +1745,15 @@ skip15: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+static int
+test_arith_ptr(dill_stream c)
+{
+    int failed = 0;
+    size_t i, j;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for dill_addp */
     if (verbose) printf("test for dill_addp");
@@ -1940,6 +1836,15 @@ skip15: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+static int
+test_arith_float(dill_stream c)
+{
+    int failed = 0;
+    size_t i, j;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for dill_addf */
     if (verbose) printf("test for dill_addf");
@@ -2270,6 +2175,15 @@ skip17: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+static int
+test_arith2_int(dill_stream c)
+{
+    int failed = 0;
+    size_t i, j;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for dill_comi */
     if (verbose) printf("test for dill_comi");
@@ -2726,6 +2640,15 @@ skip17: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+static int
+test_arith2_float(dill_stream c)
+{
+    int failed = 0;
+    size_t i, j;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for dill_negf */
     if (verbose) printf("test for dill_negf");
@@ -2802,6 +2725,15 @@ skip17: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+static int
+test_arithi(dill_stream c)
+{
+    int failed = 0;
+    size_t i, j;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for dill_addii (immediate) */
     if (verbose) printf("test for dill_addii (immediate)");
@@ -4498,6 +4430,15 @@ skip33: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+static int
+test_branch(dill_stream c)
+{
+    int failed = 0;
+    size_t i, j;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for dill_beqc */
     if (verbose) printf("test for dill_beqc");
@@ -7408,6 +7349,15 @@ skip39: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+static int
+test_branchi(dill_stream c)
+{
+    int failed = 0;
+    size_t i, j;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for dill_beqci */
     if (verbose) printf("test for dill_beqci");
@@ -9736,6 +9686,15 @@ skip45: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+static int
+test_compare(dill_stream c)
+{
+    int failed = 0;
+    size_t i, j;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for dill_eqc */
     if (verbose) printf("test for dill_eqc");
@@ -12448,6 +12407,15 @@ skip51: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+static int
+test_convert(dill_stream c)
+{
+    int failed = 0;
+    size_t i, j;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for dill_cvc2uc */
     if (verbose) printf("test for dill_cvc2uc");
@@ -16075,6 +16043,15 @@ skip51: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+static int
+test_load(dill_stream c)
+{
+    int failed = 0;
+    size_t i, j;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for dill_ldc */
     if (verbose) printf("test for dill_ldc");
@@ -16915,6 +16892,15 @@ skip51: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+static int
+test_store(dill_stream c)
+{
+    int failed = 0;
+    size_t i, j;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for dill_stc */
     if (verbose) printf("test for dill_stc");
@@ -17755,6 +17741,15 @@ skip51: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+static int
+test_setmovret(dill_stream c)
+{
+    int failed = 0;
+    size_t i, j;
+    (void)i; (void)j;  /* suppress unused warnings */
 
     /* test for set/mov/ret c */
     if (verbose) printf("test for set/mov/ret c");
@@ -18145,6 +18140,171 @@ skip51: ;
 	}
     }
     if (verbose) printf(" done\n");
+    return failed;
+}
+
+int
+main(int argc, char **argv)
+{
+    dill_stream c = dill_create_stream();
+    int failed = 0;
+
+    if (argc > 1) verbose++;
+
+    /* Initialize random values */
+    rand1_f = (float)drand48();
+    rand2_f = (float)drand48();
+    rand1_s = (short)lrand48();
+    rand2_s = (short)lrand48();
+    rand1_l = (IMM_TYPE)lrand48();
+    rand2_l = (IMM_TYPE)lrand48();
+    rand1_uc = (unsigned char)lrand48();
+    rand2_uc = (unsigned char)lrand48();
+    rand1_us = (unsigned short)lrand48();
+    rand2_us = (unsigned short)lrand48();
+    rand1_ul = (UIMM_TYPE)lrand48();
+    rand2_ul = (UIMM_TYPE)lrand48();
+    rand1_c = (signed char)lrand48();
+    rand2_c = (signed char)lrand48();
+    rand1_d = (double)drand48();
+    rand2_d = (double)drand48();
+    rand1_u = (unsigned int)lrand48();
+    rand2_u = (unsigned int)lrand48();
+    rand1_i = (int)lrand48();
+    rand2_i = (int)lrand48();
+    rand1_p = (char*)(char *)lrand48();
+    rand2_p = (char*)(char *)lrand48();
+    src1f_vals[0] = rand1_f;
+    src1f_vals[1] = -rand1_f;
+    src2f_vals[0] = rand2_f;
+    src2f_vals[1] = -rand2_f;
+    src1d_vals[0] = rand1_d;
+    src1d_vals[1] = -rand1_d;
+    src2d_vals[0] = rand2_d;
+    src2d_vals[1] = -rand2_d;
+    src1c_vals[0] = rand1_c;
+    src1c_vals[1] = -rand1_c;
+    src2c_vals[0] = rand2_c;
+    src2c_vals[1] = -rand2_c;
+    src1s_vals[0] = rand1_s;
+    src1s_vals[1] = -rand1_s;
+    src2s_vals[0] = rand2_s;
+    src2s_vals[1] = -rand2_s;
+    src1i_vals[0] = rand1_i;
+    src1i_vals[1] = -rand1_i;
+    src2i_vals[0] = rand2_i;
+    src2i_vals[1] = -rand2_i;
+    src1l_vals[0] = rand1_l;
+    src1l_vals[1] = -rand1_l;
+    src2l_vals[0] = rand2_l;
+    src2l_vals[1] = -rand2_l;
+    src1uc_vals[0] = (unsigned char) rand1_uc;
+    src1uc_vals[1] = (unsigned char) - (char) rand1_uc;
+    src2uc_vals[0] = (unsigned char) rand2_uc;
+    src2uc_vals[1] = (unsigned char) - (char) rand2_uc;
+    src1us_vals[0] = (unsigned short) rand1_us;
+    src1us_vals[1] = (unsigned short) - (short) rand1_us;
+    src2us_vals[0] = (unsigned short) rand2_us;
+    src2us_vals[1] = (unsigned short) - (short) rand2_us;
+    src1u_vals[0] = (unsigned int) rand1_u;
+    src1u_vals[1] = (unsigned int) - (int) rand1_u;
+    src2u_vals[0] = (unsigned int) rand2_u;
+    src2u_vals[1] = (unsigned int) - (int) rand2_u;
+    src1ul_vals[0] = (UIMM_TYPE) rand1_ul;
+    src1ul_vals[1] = (UIMM_TYPE) - (intptr_t) rand1_ul;
+    src2ul_vals[0] = (UIMM_TYPE) rand2_ul;
+    src2ul_vals[1] = (UIMM_TYPE) - (intptr_t) rand2_ul;
+    br_srcuc_vals[0] = (unsigned char) rand1_uc;
+    br_srcuc_vals[1] = (unsigned char) - (char) rand1_uc;
+    br_srcuc_vals[2] = (unsigned char) rand1_uc + 1;
+    br_srcuc_vals[3] = (unsigned char) -((char) rand1_uc) + 1;
+    br_srcuc_vals[4] = (unsigned char) rand1_uc - 1;
+    br_srcuc_vals[5] = (unsigned char) -((char) rand1_uc) - 1;
+    br_srcc_vals[0] = (signed char) rand1_c;
+    br_srcc_vals[1] = (signed char) -  rand1_c;
+    br_srcc_vals[2] = (signed char) rand1_c + 1;
+    br_srcc_vals[3] = (signed char) -( rand1_c) + 1;
+    br_srcc_vals[4] = (signed char) rand1_c - 1;
+    br_srcc_vals[5] = (signed char) -( rand1_c) - 1;
+    br_srcus_vals[0] = (unsigned short) rand1_us;
+    br_srcus_vals[1] = (unsigned short) - (short) rand1_us;
+    br_srcus_vals[2] = (unsigned short) rand1_us + 1;
+    br_srcus_vals[3] = (unsigned short) -((short) rand1_us) + 1;
+    br_srcus_vals[4] = (unsigned short) rand1_us - 1;
+    br_srcus_vals[5] = (unsigned short) -((short) rand1_us) - 1;
+    br_srcs_vals[0] = (short) rand1_s;
+    br_srcs_vals[1] = (short) -  rand1_s;
+    br_srcs_vals[2] = (short) rand1_s + 1;
+    br_srcs_vals[3] = (short) -( rand1_s) + 1;
+    br_srcs_vals[4] = (short) rand1_s - 1;
+    br_srcs_vals[5] = (short) -( rand1_s) - 1;
+    br_srci_vals[0] = (int) rand1_i;
+    br_srci_vals[1] = (int) -  rand1_i;
+    br_srci_vals[2] = (int) rand1_i + 1;
+    br_srci_vals[3] = (int) -( rand1_i) + 1;
+    br_srci_vals[4] = (int) rand1_i - 1;
+    br_srci_vals[5] = (int) -( rand1_i) - 1;
+    br_srcu_vals[0] = (unsigned int) rand1_u;
+    br_srcu_vals[1] = (unsigned int) - (int) rand1_u;
+    br_srcu_vals[2] = (unsigned int) rand1_u + 1;
+    br_srcu_vals[3] = (unsigned int) -((int) rand1_u) + 1;
+    br_srcu_vals[4] = (unsigned int) rand1_u - 1;
+    br_srcu_vals[5] = (unsigned int) -((int) rand1_u) - 1;
+    br_srcl_vals[0] = (IMM_TYPE) rand1_l;
+    br_srcl_vals[1] = (IMM_TYPE) -  rand1_l;
+    br_srcl_vals[2] = (IMM_TYPE) rand1_l + 1;
+    br_srcl_vals[3] = (IMM_TYPE) -( rand1_l) + 1;
+    br_srcl_vals[4] = (IMM_TYPE) rand1_l - 1;
+    br_srcl_vals[5] = (IMM_TYPE) -( rand1_l) - 1;
+    br_srcul_vals[0] = (UIMM_TYPE) rand1_ul;
+    br_srcul_vals[1] = (UIMM_TYPE) - (intptr_t) rand1_ul;
+    br_srcul_vals[2] = (UIMM_TYPE) rand1_ul + 1;
+    br_srcul_vals[3] = (UIMM_TYPE) -((intptr_t) rand1_ul) + 1;
+    br_srcul_vals[4] = (UIMM_TYPE) rand1_ul - 1;
+    br_srcul_vals[5] = (UIMM_TYPE) -((intptr_t) rand1_ul) - 1;
+    br_srcd_vals[0] = (double) rand1_d;
+    br_srcd_vals[1] = (double) -  rand1_d;
+    br_srcd_vals[2] = (double) rand1_d + 1;
+    br_srcd_vals[3] = (double) -( rand1_d) + 1;
+    br_srcd_vals[4] = (double) rand1_d - 1;
+    br_srcd_vals[5] = (double) -( rand1_d) - 1;
+    br_srcf_vals[0] = (float) rand1_f;
+    br_srcf_vals[1] = (float) -  rand1_f;
+    br_srcf_vals[2] = (float) rand1_f + 1;
+    br_srcf_vals[3] = (float) -( rand1_f) + 1;
+    br_srcf_vals[4] = (float) rand1_f - 1;
+    br_srcf_vals[5] = (float) -( rand1_f) - 1;
+    br_srcp_vals[0] = (char*) rand1_p;
+    br_srcp_vals[1] = (char*) rand1_p;
+    br_srcp_vals[2] = (char*) rand1_p + 1;
+    br_srcp_vals[3] = (char*) rand1_p + 1;
+    br_srcp_vals[4] = (char*) rand1_p - 1;
+    br_srcp_vals[5] = (char*) rand1_p - 1;
+    /* reference these values since they currently aren't done elsewhere */
+    src2p_vals[0] = src1p_vals[0] = rand1_p; src2p_vals[1] = src1p_vals[1] = rand2_p;
+    (void)src2d_vals[0];
+    (void)src2s_vals[0];
+    (void)src2p_vals[0];
+    (void)src2c_vals[0];
+    (void)src2uc_vals[0];
+    (void)src2us_vals[0];
+    (void)src2f_vals[0];
+
+    /* Call test functions */
+    failed += test_arith_int(c);
+    failed += test_arith_ptr(c);
+    failed += test_arith_float(c);
+    failed += test_arith2_int(c);
+    failed += test_arith2_float(c);
+    failed += test_arithi(c);
+    failed += test_branch(c);
+    failed += test_branchi(c);
+    failed += test_compare(c);
+    failed += test_convert(c);
+    failed += test_load(c);
+    failed += test_store(c);
+    failed += test_setmovret(c);
+
     dill_free_stream(c);
     return failed;
 }

--- a/vtests/CMakeLists.txt
+++ b/vtests/CMakeLists.txt
@@ -31,6 +31,8 @@ foreach(TEST ${TESTS})
   add_test(NAME vtest_${TEST} COMMAND v${TEST})
 endforeach()
 
+# ARM64 backend has a bug with small return types (char, short) that
+# only manifests with optimization enabled. Keep -O0 for now.
 if(NOT (CMAKE_C_COMPILER_ID MATCHES "MSVC" OR
      CMAKE_C_SIMULATE_ID MATCHES "MSVC"))
      set_target_properties(vgeneral PROPERTIES LINKER_LANGUAGE C COMPILE_FLAGS "-O0")

--- a/vtests/general.ops
+++ b/vtests/general.ops
@@ -23,34 +23,82 @@ while ($_ = $ARGV[0]) {
 
 &output_header;
 
+# Track test functions for main() to call
+@test_functions = ();
+
+# Generate separate test functions for each category
+&start_test_func("test_arith_int");
 &arith_insn("add sub mul div mod and or xor lsh rsh", "+ - * / % & | ^ << >>", "i u ul l");
+&end_test_func();
+
+&start_test_func("test_arith_ptr");
 &arithp_insn("add sub", "+ -");
+&end_test_func();
+
+&start_test_func("test_arith_float");
 &arith_insn("add sub mul div", "+ - * /",  "$FT $DT");
+&end_test_func();
 
+&start_test_func("test_arith2_int");
 &arith2_insn("com not", "~ !", "i u ul l");
-&arith2_insn("neg", "-", "i u ul l $FT $DT");
+&arith2_insn("neg", "-", "i u ul l");
+&end_test_func();
 
+&start_test_func("test_arith2_float");
+&arith2_insn("neg", "-", "$FT $DT");
+&end_test_func();
+
+&start_test_func("test_arithi");
 &arithi_insn("add sub mul div mod and or xor lsh rsh", "+ - * / % & | ^ << >>", "i u ul l");
 &arithpi_insn("add sub", "+ -","p");
+&end_test_func();
 
+&start_test_func("test_branch");
 &branch_insn( "eq ge gt le lt ne", "== >= > <= < !=", "c uc s us i u ul l p $DT $FT");
+&end_test_func();
+
+&start_test_func("test_branchi");
 &branchi_insn( "eq ge gt le lt ne", "== >= > <= < !=", "c uc s us i u ul l p");
+&end_test_func();
 
+&start_test_func("test_compare");
 &compare_insn( "eq ge gt le lt ne", "== >= > <= < !=", "c uc s us i u ul l p $DT $FT");
+&end_test_func();
 
+&start_test_func("test_convert");
 &convert( "c $DT $FT i l s u ul us", "c uc s us i u ul l");
 &convert( "$DT $FT c us s us i l u ul", "$FT $DT");
 &convert( "i l u ul", "c s");
 &convert( "p ul", "ul p");
+&end_test_func();
 
+&start_test_func("test_load");
 &load("c uc s us i u ul l $FT $DT");
+&end_test_func();
+
+&start_test_func("test_store");
 &store("c uc s us i u ul l $FT $DT");
+&end_test_func();
 
+&start_test_func("test_setmovret");
 &setmovret("c uc s us i u ul l $FT $DT");
+&end_test_func();
 
-print COUT "    dill_free_stream(c);\n";
-print COUT "    return failed;\n}\n";
+&output_main;
 
+
+sub start_test_func {
+    local ($func_name) = @_;
+    push(@test_functions, $func_name);
+    print COUT "\nstatic int\n$func_name(dill_stream c)\n{\n";
+    print COUT "    int failed = 0;\n";
+    print COUT "    size_t i, j;\n";
+    print COUT "    (void)i; (void)j;  /* suppress unused warnings */\n";
+}
+
+sub end_test_func {
+    print COUT "    return failed;\n}\n";
+}
 
 sub arith_insn {
     local ($dill_ops, $c_ops, $type_list) = @_;
@@ -1075,41 +1123,83 @@ print COUT<<EOF;
 #define srand48(s) srand(s)
 #define drand48() (rand()*(1./RAND_MAX))
 #define lrand48() ((long long)rand() << 32 | rand())
-#define kill(x,y) 
+#define kill(x,y)
 #else
 extern double drand48();
 extern IMM_TYPE lrand48();
 void srand48(IMM_TYPE seedval);
 #endif
 
-int
-main(int argc, char **argv)
-{
-    dill_stream c = dill_create_stream();
-    int failed = 0, verbose = 0;
-    size_t i, j;
+/* Global test data - initialized in main() */
+static int verbose;
 EOF
-# print COUT "# line ". (__LINE__ + 2) . " \"general.ops\"\n";
     foreach $dill_type (keys %c_types) {
         $c_type = $c_types{$dill_type};
-        $rand_type = $rand_types{$dill_type};
-        print COUT "    $c_type rand1_$dill_type = ($c_type)${rand_type}rand48();\n";
-	print COUT "    $c_type rand2_$dill_type = ($c_type)${rand_type}rand48();\n";
-	print COUT "    $c_type src1${dill_type}_vals[2];\n";
-	print COUT "    $c_type src2${dill_type}_vals[2];\n";
-	print COUT "    $c_type br_src${dill_type}_vals[6];\n";
+        print COUT "static $c_type rand1_$dill_type;\n";
+	print COUT "static $c_type rand2_$dill_type;\n";
+	print COUT "static $c_type src1${dill_type}_vals[2];\n";
+	print COUT "static $c_type src2${dill_type}_vals[2];\n";
+	print COUT "static $c_type br_src${dill_type}_vals[6];\n";
     }
-    print COUT "    int sh_src2_vals[] = {";
+    print COUT "static int sh_src2_vals[] = {";
     for (0..62) {
 	print COUT " $_,";
     }
     print COUT " 63};\n\n";
 
-    print COUT "    UIMM_TYPE bit_pattern_vals[] = {";
+    print COUT "static UIMM_TYPE bit_pattern_vals[] = {";
     for (0..31) {
 	printf COUT " 0x%x, 0x%x, ",(1<<$_), ((1<<$_) - 1);
     }
     print COUT " 0xffffffff};\n\n";
+
+    # Initialize the hash tables that map operations to test value arrays
+    %c_src2_values = ("rshi", "sh_src2_vals", "rshl", "sh_src2_vals",
+		      "rshu", "sh_src2_vals", "rshul", "sh_src2_vals",
+		      "rshii", "sh_src2_vals", "rshli", "sh_src2_vals",
+		      "rshui", "sh_src2_vals", "rshuli", "sh_src2_vals",
+		      "lshi", "sh_src2_vals", "lshl", "sh_src2_vals",
+		      "lshu", "sh_src2_vals", "lshul", "sh_src2_vals",
+		      "lshii", "sh_src2_vals", "lshli", "sh_src2_vals",
+		      "lshui", "sh_src2_vals", "lshuli", "sh_src2_vals");
+    foreach $dill_op (split(' ', "add sub mul div mod and or xor")) {
+        foreach $dill_type (split(' ', "i u l ul")) {
+	    $full_op = "${dill_op}${dill_type}i";
+	    $c_src2_values{"$full_op"} = "bit_pattern_vals";
+	}
+        foreach $dill_type (split(' ', "i u l ul")) {
+	    $full_op = "${dill_op}${dill_type}";
+	    $c_src2_values{"$full_op"} = "src2${dill_type}_vals";
+	    $c_src1_values{"$full_op"} = "src1${dill_type}_vals";
+	}
+    }
+    foreach $dill_type (split(' ', "uc c us s i u l ul d f p")) {
+	$full_op = "br${dill_type}";
+	$c_src2_values{"$full_op"} = "br_src${dill_type}_vals";
+	$c_src1_values{"$full_op"} = "br_src${dill_type}_vals";
+    }
+}
+
+sub output_main {
+    %u_casts = ('uc', '(char)', 'us', '(short)', 'u', '(int)', 'ul', '(intptr_t)');
+print COUT<<EOF;
+
+int
+main(int argc, char **argv)
+{
+    dill_stream c = dill_create_stream();
+    int failed = 0;
+
+    if (argc > 1) verbose++;
+
+    /* Initialize random values */
+EOF
+    foreach $dill_type (keys %c_types) {
+        $c_type = $c_types{$dill_type};
+        $rand_type = $rand_types{$dill_type};
+        print COUT "    rand1_$dill_type = ($c_type)${rand_type}rand48();\n";
+	print COUT "    rand2_$dill_type = ($c_type)${rand_type}rand48();\n";
+    }
 
     foreach $dill_type (split(' ', "f d c s i l")) {
         $c_type = $c_types{$dill_type};
@@ -1118,10 +1208,8 @@ EOF
 	print COUT "    src2${dill_type}_vals[0] = rand2_$dill_type;\n";
 	print COUT "    src2${dill_type}_vals[1] = -rand2_$dill_type;\n";
     }
-	%u_casts = ('uc', '(char)', 'us', '(short)', 'u', '(int)', 'ul', '(intptr_t)');
     foreach $dill_type (split(' ', "uc us u ul")) {
         $c_type = $c_types{$dill_type};
-
 	print COUT "    src1${dill_type}_vals[0] = ($c_type) rand1_$dill_type;\n";
 	print COUT "    src1${dill_type}_vals[1] = ($c_type) - $u_casts{$dill_type} rand1_$dill_type;\n";
 	print COUT "    src2${dill_type}_vals[0] = ($c_type) rand2_$dill_type;\n";
@@ -1145,7 +1233,6 @@ EOF
     print COUT "    br_src${dill_type}_vals[4] = ($c_type) rand1_$dill_type - 1;\n";
     print COUT "    br_src${dill_type}_vals[5] = ($c_type) rand1_$dill_type - 1;\n";
 
-# print COUT "# line ". (__LINE__ + 2) . " \"general.ops\"\n";
 print COUT<<EOF;
     /* reference these values since they currently aren't done elsewhere */
     src2p_vals[0] = src1p_vals[0] = rand1_p; src2p_vals[1] = src1p_vals[1] = rand2_p;
@@ -1156,30 +1243,16 @@ print COUT<<EOF;
     (void)src2uc_vals[0];
     (void)src2us_vals[0];
     (void)src2f_vals[0];
-    if (argc > 1) verbose++;
+
+    /* Call test functions */
 EOF
-    %c_src2_values = ("rshi", "sh_src2_vals", "rshl", "sh_src2_vals", 
-		      "rshu", "sh_src2_vals", "rshul", "sh_src2_vals",
-		      "rshii", "sh_src2_vals", "rshli", "sh_src2_vals", 
-		      "rshui", "sh_src2_vals", "rshuli", "sh_src2_vals",
-		      "lshi", "sh_src2_vals", "lshl", "sh_src2_vals", 
-		      "lshu", "sh_src2_vals", "lshul", "sh_src2_vals",
-		      "lshii", "sh_src2_vals", "lshli", "sh_src2_vals", 
-		      "lshui", "sh_src2_vals", "lshuli", "sh_src2_vals");
-    foreach $dill_op (split(' ', "add sub mul div mod and or xor")) {
-        foreach $dill_type (split(' ', "i u l ul")) {
-	    $full_op = "${dill_op}${dill_type}i";
-	    $c_src2_values{"$full_op"} = "bit_pattern_vals";
-	}
-        foreach $dill_type (split(' ', "i u l ul")) {
-	    $full_op = "${dill_op}${dill_type}";
-	    $c_src2_values{"$full_op"} = "src2${dill_type}_vals";
-	    $c_src1_values{"$full_op"} = "src1${dill_type}_vals";
-	}
+    foreach $func (@test_functions) {
+	print COUT "    failed += $func(c);\n";
     }
-    foreach $dill_type (split(' ', "uc c us s i u l ul d f p")) {
-	$full_op = "br${dill_type}";
-	$c_src2_values{"$full_op"} = "br_src${dill_type}_vals";
-	$c_src1_values{"$full_op"} = "br_src${dill_type}_vals";
-    }
+print COUT<<EOF;
+
+    dill_free_stream(c);
+    return failed;
+}
+EOF
 }


### PR DESCRIPTION
Split general.c into separate test functions for independent optimization.

Keep -O0 flag - ARM64 backend has return type bug exposed by optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)