### PR TITLE
Fix x86 div/mod when divisor is in EAX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 # The directory label is used for CDash to treat DILL as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS DILL)
 
-project(DILL VERSION 3.2.0 LANGUAGES C CXX)
+project(DILL VERSION 3.2.1 LANGUAGES C CXX)
 
 # Some boilerplate to setup nice output directories
 include(GNUInstallDirs)


### PR DESCRIPTION
Save divisor to EBP before overwriting EAX with dividend.