### PR TITLE
Add dill_free() function for Windows DLL heap compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 # The directory label is used for CDash to treat DILL as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS DILL)
 
-project(DILL VERSION 3.2.2 LANGUAGES C CXX)
+project(DILL VERSION 3.3.0 LANGUAGES C CXX)
 
 # Some boilerplate to setup nice output directories
 include(GNUInstallDirs)

--- a/pregen-source/dill.h
+++ b/pregen-source/dill.h
@@ -200,6 +200,7 @@ extern dill_stream dill_dup_stream(dill_stream s);
 extern dill_exec_ctx dill_get_exec_context(dill_stream x);
 extern void dill_free_stream(dill_stream s);
 extern void dill_free_exec_context(dill_exec_ctx c);
+extern void dill_free(void *ptr);
 extern void dill_assoc_client_data(dill_exec_ctx ec, int key, IMM_TYPE value);
 extern IMM_TYPE dill_get_client_data(dill_exec_ctx ec, int key);
 extern void* dill_take_code(dill_stream s);

--- a/virtual.c
+++ b/virtual.c
@@ -4618,6 +4618,12 @@ dill_free_exec_context(dill_exec_ctx ec)
 }
 
 extern void
+dill_free(void *ptr)
+{
+    free(ptr);
+}
+
+extern void
 dill_assoc_client_data(dill_exec_ctx ec, int key, IMM_TYPE value)
 {
     int i = 0;


### PR DESCRIPTION
## Summary
- Add `dill_free()` function to properly free memory allocated by DILL on Windows
- Bump version to 3.3.0

## Background
On Windows, each DLL has its own CRT heap. Memory allocated inside one DLL must be freed by the same DLL. Functions like `dill_finalize_package()` allocate memory that callers need to free, but if the caller is in a different DLL (like FFS), calling `free()` directly causes heap corruption.

This is the same pattern as the `atl_free()` function added in GTKorvo/atl#41 and `ffs_free()` in GTKorvo/ffs#107.

## Test plan
- Build on Windows and verify that cross-DLL memory freeing works correctly
- Existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)