### PR TITLE
Add global register pre-assignment for virtual mode loops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 # The directory label is used for CDash to treat DILL as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS DILL)
 
-project(DILL VERSION 3.3.0 LANGUAGES C CXX)
+project(DILL VERSION 3.4.0 LANGUAGES C CXX)
 
 # Some boilerplate to setup nice output directories
 include(GNUInstallDirs)

--- a/virtual.c
+++ b/virtual.c
@@ -528,15 +528,15 @@ dump_bbs(dill_stream c)
 
 #if defined(__GNUC__) && !defined(__clang__)
 #if defined __GNUC__ && defined __GNUC_MINOR__
-# define __GNUC_PREREQ(maj, min) \
-        ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((maj) << 16) + (min))
+#define __GNUC_PREREQ(maj, min)                                                \
+    ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((maj) << 16) + (min))
 #else
-# define __GNUC_PREREQ(maj, min) 0
+#define __GNUC_PREREQ(maj, min) 0
 #endif
-#  if __GNUC_PREREQ(4,6)
+#if __GNUC_PREREQ(4, 6)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
-#  endif
+#endif
 #endif
 /* overflow is confused about operation on bit_vec->vec, suppress warning */
 static int
@@ -567,9 +567,9 @@ remove_regs(bit_vec dest, bit_vec src)
     }
 }
 #if defined(__GNUC__) && !defined(__clang__)
-#  if __GNUC_PREREQ(4,6)
+#if __GNUC_PREREQ(4, 6)
 #pragma GCC diagnostic pop
-#  endif
+#endif
 #endif
 
 static void
@@ -1581,6 +1581,106 @@ do_register_assign(dill_stream c,
     }
 }
 
+typedef struct {
+    int vreg_idx;
+    int score;
+    int typ;
+} global_assign_candidate;
+
+static int
+compare_candidates(const void* a, const void* b)
+{
+    const global_assign_candidate* ca = (const global_assign_candidate*)a;
+    const global_assign_candidate* cb = (const global_assign_candidate*)b;
+    return cb->score - ca->score; /* descending by score */
+}
+
+static void
+do_global_assign(dill_stream c, virtual_mach_info vmi)
+{
+    int i, j;
+    int candidate_count = 0;
+    global_assign_candidate* candidates;
+
+    /* Initialize all vregs */
+    for (i = 0; i < c->p->vreg_count; i++) {
+        c->p->vregs[i].preg = -1;
+        c->p->vregs[i].need_assign = 0;
+    }
+
+    /* Collect cross-block vregs: those live_at_end in any basic block */
+    candidates = malloc(sizeof(global_assign_candidate) * c->p->vreg_count);
+    for (i = 0; i < c->p->vreg_count; i++) {
+        int is_cross_block = 0;
+        if (c->p->vregs[i].typ == DILL_B || c->p->vregs[i].typ == DILL_V)
+            continue;
+        if (c->p->vregs[i].use_info.use_count == 0 &&
+            c->p->vregs[i].use_info.def_count == 0)
+            continue;
+        for (j = 0; j < vmi->bbcount; j++) {
+            if (bit_vec_is_set(vmi->bblist[j].live_at_end, i)) {
+                is_cross_block = 1;
+                break;
+            }
+        }
+        if (is_cross_block) {
+            candidates[candidate_count].vreg_idx = i;
+            candidates[candidate_count].score =
+                c->p->vregs[i].use_info.use_count +
+                c->p->vregs[i].use_info.def_count;
+            candidates[candidate_count].typ = c->p->vregs[i].typ;
+            candidate_count++;
+        }
+    }
+
+    /* Sort by score descending — most-used vregs get registers first */
+    if (candidate_count > 0)
+        qsort(candidates, candidate_count, sizeof(global_assign_candidate),
+              compare_candidates);
+
+    /* Allocate physical registers for top candidates.
+     * Reserve MIN_ONDEMAND registers so the on-demand allocator in
+     * select_reg() can still function for non-pre-assigned vregs.
+     */
+#define MIN_ONDEMAND_RESERVE 3
+    for (i = 0; i < candidate_count; i++) {
+        int preg;
+        int idx = candidates[i].vreg_idx;
+        int probe[MIN_ONDEMAND_RESERVE];
+        int got, k;
+
+        if (dill_raw_getreg(c, &preg, candidates[i].typ, DILL_VAR) == 0)
+            break; /* no more registers available */
+
+        /* Verify enough registers remain for on-demand allocation */
+        got = 0;
+        for (k = 0; k < MIN_ONDEMAND_RESERVE; k++) {
+            if (dill_raw_getreg(c, &probe[k], candidates[i].typ, DILL_VAR))
+                got++;
+            else
+                break;
+        }
+        /* Return probe registers */
+        for (k = 0; k < got; k++)
+            dill_raw_putreg(c, probe[k], candidates[i].typ);
+
+        if (got < MIN_ONDEMAND_RESERVE) {
+            /* Pool is too depleted — return this register and stop */
+            dill_raw_putreg(c, preg, candidates[i].typ);
+            break;
+        }
+
+        c->p->vregs[idx].preg = preg;
+        c->p->vregs[idx].need_assign = 1;
+        if (c->dill_debug)
+            printf("Global assign: vreg %d (score %d) -> preg %d\n", idx + 100,
+                   candidates[i].score, preg);
+        /* Don't putreg — keep it reserved for the lifetime of the function */
+    }
+
+    free(candidates);
+}
+
 static int
 preg_of(dill_stream c, basic_block bb, int vreg)
 {
@@ -1785,7 +1885,7 @@ typedef struct label_translation {
     int old_location;
     int old_label;
     int new_label;
-} * label_translation_table;
+}* label_translation_table;
 
 static int
 get_new_label(int old_label, label_translation_table ltable)
@@ -2653,11 +2753,39 @@ init_reg_state(reg_state* state, dill_stream c)
 }
 
 static void
+ensure_preg_capacity(reg_state* state, int preg)
+{
+    if (preg >= state->reg_count) {
+        int i;
+        state->fpregs = realloc(state->fpregs, sizeof(preg_info) * (preg + 1));
+        state->ipregs = realloc(state->ipregs, sizeof(preg_info) * (preg + 1));
+        for (i = state->reg_count; i <= preg; i++) {
+            state->ipregs[i].holds = state->fpregs[i].holds = -1;
+        }
+        state->reg_count = preg + 1;
+    }
+}
+
+static void
 reset_reg_state(reg_state* state)
 {
     int i;
+    dill_stream c = state->c;
     for (i = 0; i < state->reg_count; i++) {
         state->fpregs[i].holds = state->ipregs[i].holds = -1;
+    }
+    /* Re-populate pre-assigned register holdings */
+    for (i = 0; i < c->p->vreg_count; i++) {
+        if (c->p->vregs[i].need_assign == 1 && c->p->vregs[i].preg != -1) {
+            int preg = c->p->vregs[i].preg;
+            int typ = c->p->vregs[i].typ;
+            ensure_preg_capacity(state, preg);
+            if (typ == DILL_F || typ == DILL_D) {
+                state->fpregs[preg].holds = i + 100;
+            } else {
+                state->ipregs[preg].holds = i + 100;
+            }
+        }
     }
 }
 
@@ -2828,6 +2956,13 @@ spill_current_pregs(reg_state* state)
         for (i = 0; i < state->reg_count; i++) {
             int vreg = pregs[i].holds;
             if (vreg >= 100) {
+                int is_preassigned = (vregs[vreg - 100].need_assign == 1 &&
+                                      vregs[vreg - 100].preg == i);
+                if (is_preassigned) {
+                    /* Pre-assigned: value stays in register across blocks.
+                     * No spill, no release. */
+                    continue;
+                }
                 if (update_in_reg(state, vreg) && live_at_end(bb, vreg)) {
                     int offset = offset_of(c, vreg);
                     int typ = dill_type_of(c, vreg);
@@ -3119,6 +3254,14 @@ new_emit_insns(dill_stream c,
                 (c->p->vregs[j].last_use - c->p->vregs[j].value_in_mem + 1);
             c->p->vregs[j].value_in_mem = bit_vec_is_set(bb->regs_used, (int)j);
         }
+        /* Set up pre-assigned vreg state: value is in the physical register */
+        for (j = 0; j < (size_t)c->p->vreg_count; j++) {
+            if (c->p->vregs[j].need_assign == 1 && c->p->vregs[j].preg != -1) {
+                c->p->vregs[j].in_reg = c->p->vregs[j].preg;
+                c->p->vregs[j].update_in_reg = 0;
+                c->p->vregs[j].value_in_mem = 0; /* value is in register */
+            }
+        }
         for (j = 0; j < (size_t)c->p->c_param_count; j++) {
             if (c->p->c_param_args[j].is_register) {
                 state.param_info[j].update_in_reg = 0;
@@ -3132,7 +3275,8 @@ new_emit_insns(dill_stream c,
         }
         reset_reg_state(&state);
         if (c->dill_debug) {
-            printf("============= Starting basic block %d ===========\n", (int)i);
+            printf("============= Starting basic block %d ===========\n",
+                   (int)i);
             dump_bb(c, bb, (int)i);
         }
         insn_start = (int)((char*)c->p->cur_ip - (char*)c->p->code_base);
@@ -4498,8 +4642,8 @@ virtual_do_end(dill_stream s, int package)
         if (vmi->prefix_code_start == -1) {
             dill_retii(s, 0);
             s->p->virtual.cur_ip = s->p->cur_ip;
-	    s->p->virtual.code_base = s->p->code_base;
-	    s->p->virtual.code_limit = s->p->code_limit;
+            s->p->virtual.code_base = s->p->code_base;
+            s->p->virtual.code_limit = s->p->code_limit;
         }
         setup_VM_proc(s);
 #endif
@@ -4532,6 +4676,7 @@ virtual_do_end(dill_stream s, int package)
             do_register_assign(s, insns, code_end, virtual_local_pointer, vmi);
             emit_insns(s, insns, ltable, vmi);
         } else {
+            do_global_assign(s, vmi);
             new_emit_insns(s, insns, ltable, vmi);
         }
         free_bbs(vmi);
@@ -4618,7 +4763,7 @@ dill_free_exec_context(dill_exec_ctx ec)
 }
 
 extern void
-dill_free(void *ptr)
+dill_free(void* ptr)
 {
     free(ptr);
 }

--- a/vtests/CMakeLists.txt
+++ b/vtests/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(TESTS basic_call general t1 opt branch prefix_test mixed_params)
+set(TESTS basic_call general t1 opt branch prefix_test mixed_params loop_reg)
 
 if(NATIVE_CG)
   list(APPEND TESTS pkg_test multi_test)
@@ -37,6 +37,9 @@ if(NOT (CMAKE_C_COMPILER_ID MATCHES "MSVC" OR
      CMAKE_C_SIMULATE_ID MATCHES "MSVC"))
      set_target_properties(vgeneral PROPERTIES LINKER_LANGUAGE C COMPILE_FLAGS "-O0")
 ENDIF()
+
+set_tests_properties(vtest_loop_reg
+  PROPERTIES PASS_REGULAR_EXPRESSION "No errors!")
 
 set_tests_properties(vtest_basic_call
   PROPERTIES PASS_REGULAR_EXPRESSION "########## A

--- a/vtests/loop_reg.c
+++ b/vtests/loop_reg.c
@@ -1,0 +1,621 @@
+/*
+ * Tests for virtual register allocation across loop back-edges.
+ *
+ * These tests exercise the global pre-assignment path (do_global_assign)
+ * which pins cross-block virtual registers to callee-saved physical
+ * registers so they survive loop iterations without spill/reload.
+ */
+#include "dill.h"
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+
+static int verbose = 0;
+
+/*
+ * Test 1: Tight array computation loop — the ADIOS2 pattern.
+ *
+ * Generates: out[i] = A[i]*A[i] + B[i]*B[i] + C[i]*C[i]
+ * for i in [0, N).
+ *
+ * Cross-block vregs: pA, pB, pC, pOut (pointers), off (byte offset), N.
+ * Float temporaries are block-local.
+ */
+static int
+test_array_loop(void)
+{
+    dill_stream s = dill_create_stream();
+    dill_exec_handle handle;
+    void (*func)(double*, double*, double*, double*, long);
+    dill_reg pA, pB, pC, pOut, off, limit;
+    dill_reg va, vb, vc, t1, t2;
+    int L_top, L_end;
+    int i, failure = 0;
+    const int N = 64;
+    double A[64], B[64], C[64], out[64];
+
+    /* Set up input data */
+    for (i = 0; i < N; i++) {
+        A[i] = (double)(i + 1);
+        B[i] = (double)(i + 2);
+        C[i] = (double)(i + 3);
+        out[i] = -1.0;
+    }
+
+    dill_start_proc(s, "array_loop", DILL_V, "%p%p%p%p%l");
+    pA = dill_vparam(s, 0);
+    pB = dill_vparam(s, 1);
+    pC = dill_vparam(s, 2);
+    pOut = dill_vparam(s, 3);
+    limit = dill_vparam(s, 4);
+
+    off = dill_getreg(s, DILL_L);
+    va = dill_getreg(s, DILL_D);
+    vb = dill_getreg(s, DILL_D);
+    vc = dill_getreg(s, DILL_D);
+    t1 = dill_getreg(s, DILL_D);
+    t2 = dill_getreg(s, DILL_D);
+
+    L_top = dill_alloc_label(s, "loop_top");
+    L_end = dill_alloc_label(s, "loop_end");
+
+    /* Convert element count to byte limit: limit *= 8 */
+    dill_mulli(s, limit, limit, (IMM_TYPE)8);
+    dill_setl(s, off, (IMM_TYPE)0);
+
+    /* Loop top */
+    dill_mark_label(s, L_top);
+    dill_bgel(s, off, limit, L_end);
+
+    /* Load A[i], B[i], C[i] via base+offset */
+    dill_ldd(s, va, pA, off);
+    dill_ldd(s, vb, pB, off);
+    dill_ldd(s, vc, pC, off);
+
+    /* Compute A*A + B*B + C*C */
+    dill_muld(s, t1, va, va);
+    dill_muld(s, t2, vb, vb);
+    dill_addd(s, t1, t1, t2);
+    dill_muld(s, t2, vc, vc);
+    dill_addd(s, t1, t1, t2);
+
+    /* Store result */
+    dill_std(s, t1, pOut, off);
+
+    /* Advance offset by sizeof(double) */
+    dill_addli(s, off, off, (IMM_TYPE)8);
+    dill_jv(s, L_top);
+    dill_mark_label(s, L_end);
+    dill_retii(s, 0);
+
+    handle = dill_finalize(s);
+    func =
+        (void (*)(double*, double*, double*, double*, long))dill_get_fp(handle);
+
+    if (verbose)
+        dill_dump(s);
+
+    (*func)(A, B, C, out, (long)N);
+
+    /* Verify results */
+    for (i = 0; i < N; i++) {
+        double expected = A[i] * A[i] + B[i] * B[i] + C[i] * C[i];
+        if (out[i] != expected) {
+            if (verbose)
+                printf("  array_loop: out[%d] = %g, expected %g\n", i, out[i],
+                       expected);
+            failure = 1;
+        }
+    }
+
+    dill_free_handle(handle);
+    dill_free_stream(s);
+    return failure;
+}
+
+/*
+ * Test 2: Register pressure overflow.
+ *
+ * Uses 20 integer vregs that are all live across the loop back-edge.
+ * Most architectures have fewer than 20 callee-saved registers,
+ * so some vregs must fall back to on-demand allocation with spills.
+ * Verifies correctness when pre-assignment runs out of registers.
+ *
+ * Computes: sum = v0 + v1 + ... + v19, where each vi is initialized
+ * to (i+1) and incremented each iteration. After N iterations,
+ * vi = (i+1) + N, and sum = sum((i+1)+N for i in 0..19) = 20*N + 210.
+ */
+static int
+test_pressure_overflow(void)
+{
+    dill_stream s = dill_create_stream();
+    dill_exec_handle handle;
+    long (*func)(long);
+    dill_reg v[20], sum, cnt, limit;
+    int L_top, L_end;
+    int i, failure = 0;
+    const int NREGS = 20;
+    const long NITER = 10;
+
+    dill_start_proc(s, "pressure", DILL_L, "%l");
+    limit = dill_vparam(s, 0);
+
+    for (i = 0; i < NREGS; i++) {
+        v[i] = dill_getreg(s, DILL_L);
+    }
+    sum = dill_getreg(s, DILL_L);
+    cnt = dill_getreg(s, DILL_L);
+
+    L_top = dill_alloc_label(s, "loop_top");
+    L_end = dill_alloc_label(s, "loop_end");
+
+    /* Initialize: v[i] = i + 1 */
+    for (i = 0; i < NREGS; i++) {
+        dill_setl(s, v[i], (IMM_TYPE)(i + 1));
+    }
+    dill_setl(s, cnt, (IMM_TYPE)0);
+
+    /* Loop: increment all vregs each iteration */
+    dill_mark_label(s, L_top);
+    dill_bgel(s, cnt, limit, L_end);
+    for (i = 0; i < NREGS; i++) {
+        dill_addli(s, v[i], v[i], (IMM_TYPE)1);
+    }
+    dill_addli(s, cnt, cnt, (IMM_TYPE)1);
+    dill_jv(s, L_top);
+    dill_mark_label(s, L_end);
+
+    /* Sum all vregs */
+    dill_movl(s, sum, v[0]);
+    for (i = 1; i < NREGS; i++) {
+        dill_addl(s, sum, sum, v[i]);
+    }
+    dill_retl(s, sum);
+
+    handle = dill_finalize(s);
+    func = (long (*)(long))dill_get_fp(handle);
+
+    if (verbose)
+        dill_dump(s);
+
+    {
+        long result = (*func)(NITER);
+        /* sum = sum_{i=0}^{19} ((i+1) + NITER) = 20*NITER + 20*21/2 */
+        long expected = NREGS * NITER + (NREGS * (NREGS + 1)) / 2;
+        if (result != expected) {
+            if (verbose)
+                printf("  pressure: result = %ld, expected %ld\n", result,
+                       expected);
+            failure = 1;
+        }
+    }
+
+    dill_free_handle(handle);
+    dill_free_stream(s);
+    return failure;
+}
+
+/*
+ * Test 3: Mixed int + float cross-block registers.
+ *
+ * A loop where both integer vregs (pointers, index) and float vregs
+ * (running sums) are live across the back-edge.
+ *
+ * Computes: sumA = sum(A[i]), sumB = sum(B[i]) for i in [0, N).
+ * Returns sumA + sumB as a double.
+ */
+static int
+test_mixed_loop(void)
+{
+    dill_stream s = dill_create_stream();
+    dill_exec_handle handle;
+    double (*func)(double*, double*, long);
+    dill_reg pA, pB, off, limit;
+    dill_reg sumA, sumB, total, tmp;
+    int L_top, L_end;
+    int i, failure = 0;
+    const int N = 32;
+    double A[32], B[32];
+
+    for (i = 0; i < N; i++) {
+        A[i] = (double)(i + 1);       /* 1, 2, ..., 32 */
+        B[i] = (double)(i + 1) * 0.5; /* 0.5, 1.0, ..., 16.0 */
+    }
+
+    dill_start_proc(s, "mixed_loop", DILL_D, "%p%p%l");
+    pA = dill_vparam(s, 0);
+    pB = dill_vparam(s, 1);
+    limit = dill_vparam(s, 2);
+
+    off = dill_getreg(s, DILL_L);
+    sumA = dill_getreg(s, DILL_D);
+    sumB = dill_getreg(s, DILL_D);
+    total = dill_getreg(s, DILL_D);
+    tmp = dill_getreg(s, DILL_D);
+
+    L_top = dill_alloc_label(s, "loop_top");
+    L_end = dill_alloc_label(s, "loop_end");
+
+    dill_mulli(s, limit, limit, (IMM_TYPE)8);
+    dill_setl(s, off, (IMM_TYPE)0);
+    dill_setd(s, sumA, 0.0);
+    dill_setd(s, sumB, 0.0);
+
+    dill_mark_label(s, L_top);
+    dill_bgel(s, off, limit, L_end);
+
+    dill_ldd(s, tmp, pA, off);
+    dill_addd(s, sumA, sumA, tmp);
+
+    dill_ldd(s, tmp, pB, off);
+    dill_addd(s, sumB, sumB, tmp);
+
+    dill_addli(s, off, off, (IMM_TYPE)8);
+    dill_jv(s, L_top);
+    dill_mark_label(s, L_end);
+
+    dill_addd(s, total, sumA, sumB);
+    dill_retd(s, total);
+
+    handle = dill_finalize(s);
+    func = (double (*)(double*, double*, long))dill_get_fp(handle);
+
+    if (verbose)
+        dill_dump(s);
+
+    {
+        double result = (*func)(A, B, (long)N);
+        /* sumA = 32*33/2 = 528, sumB = 528*0.5 = 264, total = 792 */
+        double expected = 792.0;
+        if (result != expected) {
+            if (verbose)
+                printf("  mixed_loop: result = %g, expected %g\n", result,
+                       expected);
+            failure = 1;
+        }
+    }
+
+    dill_free_handle(handle);
+    dill_free_stream(s);
+    return failure;
+}
+
+/*
+ * Test 4: Nested loops.
+ *
+ * Outer loop iterates over rows, inner loop over columns.
+ * Computes: out[i] = sum(M[i][j] for j in [0, COLS))
+ * M is stored as a flat array M[i*COLS + j].
+ *
+ * Outer-loop vregs (row index, output pointer, matrix pointer)
+ * must survive across ALL inner-loop basic blocks.
+ */
+static int
+test_nested_loop(void)
+{
+    dill_stream s = dill_create_stream();
+    dill_exec_handle handle;
+    void (*func)(double*, double*, long, long);
+    dill_reg pM, pOut, nrows, ncols;
+    dill_reg row, col, row_off, elem_off;
+    dill_reg sum, tmp;
+    int L_outer, L_outer_end, L_inner, L_inner_end;
+    int i, j, failure = 0;
+    const int ROWS = 8, COLS = 8;
+    double M[64], out[8];
+
+    for (i = 0; i < ROWS; i++)
+        for (j = 0; j < COLS; j++)
+            M[i * COLS + j] = (double)(i * COLS + j + 1);
+    memset(out, 0, sizeof(out));
+
+    dill_start_proc(s, "nested_loop", DILL_V, "%p%p%l%l");
+    pM = dill_vparam(s, 0);
+    pOut = dill_vparam(s, 1);
+    nrows = dill_vparam(s, 2);
+    ncols = dill_vparam(s, 3);
+
+    row = dill_getreg(s, DILL_L);
+    col = dill_getreg(s, DILL_L);
+    row_off = dill_getreg(s, DILL_L);
+    elem_off = dill_getreg(s, DILL_L);
+    sum = dill_getreg(s, DILL_D);
+    tmp = dill_getreg(s, DILL_D);
+
+    L_outer = dill_alloc_label(s, "outer_top");
+    L_outer_end = dill_alloc_label(s, "outer_end");
+    L_inner = dill_alloc_label(s, "inner_top");
+    L_inner_end = dill_alloc_label(s, "inner_end");
+
+    /* Convert counts to byte counts */
+    dill_mulli(s, nrows, nrows, (IMM_TYPE)8);
+    dill_mulli(s, ncols, ncols, (IMM_TYPE)8);
+
+    dill_setl(s, row, (IMM_TYPE)0);
+    dill_setl(s, row_off, (IMM_TYPE)0);
+
+    /* Outer loop: rows */
+    dill_mark_label(s, L_outer);
+    dill_bgel(s, row, nrows, L_outer_end);
+
+    dill_setd(s, sum, 0.0);
+    dill_setl(s, col, (IMM_TYPE)0);
+
+    /* Inner loop: columns */
+    dill_mark_label(s, L_inner);
+    dill_bgel(s, col, ncols, L_inner_end);
+
+    /* elem_off = row_off + col (both in bytes already) */
+    dill_addl(s, elem_off, row_off, col);
+    dill_ldd(s, tmp, pM, elem_off);
+    dill_addd(s, sum, sum, tmp);
+
+    dill_addli(s, col, col, (IMM_TYPE)8);
+    dill_jv(s, L_inner);
+    dill_mark_label(s, L_inner_end);
+
+    /* Store row sum: out[row] = sum */
+    dill_std(s, sum, pOut, row);
+
+    dill_addli(s, row, row, (IMM_TYPE)8);
+    /* row_off += ncols (advance by one row of bytes) */
+    dill_addl(s, row_off, row_off, ncols);
+    dill_jv(s, L_outer);
+    dill_mark_label(s, L_outer_end);
+    dill_retii(s, 0);
+
+    handle = dill_finalize(s);
+    func = (void (*)(double*, double*, long, long))dill_get_fp(handle);
+
+    if (verbose)
+        dill_dump(s);
+
+    (*func)(M, out, (long)ROWS, (long)COLS);
+
+    for (i = 0; i < ROWS; i++) {
+        double expected = 0.0;
+        for (j = 0; j < COLS; j++)
+            expected += M[i * COLS + j];
+        if (out[i] != expected) {
+            if (verbose)
+                printf("  nested_loop: out[%d] = %g, expected %g\n", i, out[i],
+                       expected);
+            failure = 1;
+        }
+    }
+
+    dill_free_handle(handle);
+    dill_free_stream(s);
+    return failure;
+}
+
+/*
+ * Test 5: Diamond control flow (if/else merge).
+ *
+ * Computes: if (sel) result = a*a + b*b; else result = a + b;
+ * Where a, b are pre-assigned vregs that survive across both branches.
+ *
+ * BB0: define a, b, sel → branch
+ * BB1 (then): t = a*a + b*b → jump merge
+ * BB2 (else): t = a + b → fall through
+ * BB3 (merge): return t + a (a must still be valid here)
+ */
+static int
+test_diamond(void)
+{
+    dill_stream s = dill_create_stream();
+    dill_exec_handle handle;
+    long (*func)(long, long, long);
+    dill_reg a, b, sel, t;
+    int L_else, L_merge;
+    int failure = 0;
+
+    dill_start_proc(s, "diamond", DILL_L, "%l%l%l");
+    a = dill_vparam(s, 0);
+    b = dill_vparam(s, 1);
+    sel = dill_vparam(s, 2);
+
+    t = dill_getreg(s, DILL_L);
+
+    L_else = dill_alloc_label(s, "else");
+    L_merge = dill_alloc_label(s, "merge");
+
+    /* BB0: branch on sel */
+    dill_beqli(s, sel, (IMM_TYPE)0, L_else);
+
+    /* BB1 (then): t = a*a + b*b */
+    dill_mull(s, t, a, a);
+    {
+        dill_reg tmp = dill_getreg(s, DILL_L);
+        dill_mull(s, tmp, b, b);
+        dill_addl(s, t, t, tmp);
+    }
+    dill_jv(s, L_merge);
+
+    /* BB2 (else): t = a + b */
+    dill_mark_label(s, L_else);
+    dill_addl(s, t, a, b);
+
+    /* BB3 (merge): return t + a */
+    dill_mark_label(s, L_merge);
+    dill_addl(s, t, t, a);
+    dill_retl(s, t);
+
+    handle = dill_finalize(s);
+    func = (long (*)(long, long, long))dill_get_fp(handle);
+
+    if (verbose)
+        dill_dump(s);
+
+    {
+        /* sel=1: t = 3*3 + 4*4 = 25, result = 25 + 3 = 28 */
+        long r1 = (*func)(3, 4, 1);
+        /* sel=0: t = 3 + 4 = 7, result = 7 + 3 = 10 */
+        long r2 = (*func)(3, 4, 0);
+        if (r1 != 28) {
+            if (verbose)
+                printf("  diamond(sel=1): result = %ld, expected 28\n", r1);
+            failure = 1;
+        }
+        if (r2 != 10) {
+            if (verbose)
+                printf("  diamond(sel=0): result = %ld, expected 10\n", r2);
+            failure = 1;
+        }
+    }
+
+    dill_free_handle(handle);
+    dill_free_stream(s);
+    return failure;
+}
+
+/*
+ * Test 6: Loop with function call.
+ *
+ * A loop that calls an external function each iteration.
+ * Pre-assigned callee-saved registers (pointers, index) must
+ * survive the call. Verifies values are correct after each call.
+ *
+ * Computes: sum += scale_val(A[i]) for i in [0, N)
+ * where scale_val(x) returns x * 2.
+ */
+static long
+scale_val(long x)
+{
+    return x * 2;
+}
+
+static int
+test_loop_with_call(void)
+{
+    dill_stream s = dill_create_stream();
+    dill_exec_handle handle;
+    long (*func)(long*, long);
+    dill_reg pA, limit, off, sum, tmp, ret;
+    int L_top, L_end;
+    int i, failure = 0;
+    const int N = 16;
+    long A[16];
+
+    for (i = 0; i < N; i++)
+        A[i] = (long)(i + 1);
+
+    dill_start_proc(s, "loop_call", DILL_L, "%p%l");
+    pA = dill_vparam(s, 0);
+    limit = dill_vparam(s, 1);
+
+    off = dill_getreg(s, DILL_L);
+    sum = dill_getreg(s, DILL_L);
+    tmp = dill_getreg(s, DILL_L);
+
+    L_top = dill_alloc_label(s, "loop_top");
+    L_end = dill_alloc_label(s, "loop_end");
+
+    dill_mulli(s, limit, limit, (IMM_TYPE)8);
+    dill_setl(s, off, (IMM_TYPE)0);
+    dill_setl(s, sum, (IMM_TYPE)0);
+
+    dill_mark_label(s, L_top);
+    dill_bgel(s, off, limit, L_end);
+
+    /* tmp = A[off] */
+    dill_ldl(s, tmp, pA, off);
+
+    /* call scale_val(tmp) */
+    dill_push_init(s);
+    dill_push_argl(s, tmp);
+    ret = dill_calll(s, (void*)scale_val, "scale_val");
+
+    /* sum += return value */
+    dill_addl(s, sum, sum, ret);
+
+    dill_addli(s, off, off, (IMM_TYPE)8);
+    dill_jv(s, L_top);
+    dill_mark_label(s, L_end);
+
+    dill_retl(s, sum);
+
+    handle = dill_finalize(s);
+    func = (long (*)(long*, long))dill_get_fp(handle);
+
+    if (verbose)
+        dill_dump(s);
+
+    {
+        long result = (*func)(A, (long)N);
+        /* sum = 2 * sum(1..16) = 2 * 136 = 272 */
+        long expected = 272;
+        if (result != expected) {
+            if (verbose)
+                printf("  loop_call: result = %ld, expected %ld\n", result,
+                       expected);
+            failure = 1;
+        }
+    }
+
+    dill_free_handle(handle);
+    dill_free_stream(s);
+    return failure;
+}
+
+int
+main(int argc, char** argv)
+{
+    int failure = 0;
+
+    if (argc > 1)
+        verbose++;
+
+    printf("Test 1: array loop (A*A+B*B+C*C)... ");
+    if (test_array_loop()) {
+        printf("FAILED\n");
+        failure = 1;
+    } else {
+        printf("passed\n");
+    }
+
+    printf("Test 2: register pressure overflow (20 cross-block vregs)... ");
+    if (test_pressure_overflow()) {
+        printf("FAILED\n");
+        failure = 1;
+    } else {
+        printf("passed\n");
+    }
+
+    printf("Test 3: mixed int+float loop... ");
+    if (test_mixed_loop()) {
+        printf("FAILED\n");
+        failure = 1;
+    } else {
+        printf("passed\n");
+    }
+
+    printf("Test 4: nested loops... ");
+    if (test_nested_loop()) {
+        printf("FAILED\n");
+        failure = 1;
+    } else {
+        printf("passed\n");
+    }
+
+    printf("Test 5: diamond control flow (if/else merge)... ");
+    if (test_diamond()) {
+        printf("FAILED\n");
+        failure = 1;
+    } else {
+        printf("passed\n");
+    }
+
+    printf("Test 6: loop with function call... ");
+    if (test_loop_with_call()) {
+        printf("FAILED\n");
+        failure = 1;
+    } else {
+        printf("passed\n");
+    }
+
+    if (!failure) {
+        printf("No errors!\n");
+    }
+    return failure;
+}

--- a/vtests/loop_reg.c
+++ b/vtests/loop_reg.c
@@ -476,11 +476,14 @@ test_diamond(void)
  * Pre-assigned callee-saved registers (pointers, index) must
  * survive the call. Verifies values are correct after each call.
  *
+ * Uses int/DILL_I for the call and accumulator (not long) because
+ * C 'long' is 32-bit on Windows but DILL_L is 64-bit.
+ *
  * Computes: sum += scale_val(A[i]) for i in [0, N)
  * where scale_val(x) returns x * 2.
  */
-static long
-scale_val(long x)
+static int
+scale_val(int x)
 {
     return x * 2;
 }
@@ -490,64 +493,64 @@ test_loop_with_call(void)
 {
     dill_stream s = dill_create_stream();
     dill_exec_handle handle;
-    long (*func)(long*, long);
+    int (*func)(int*, int);
     dill_reg pA, limit, off, sum, tmp, ret;
     int L_top, L_end;
     int i, failure = 0;
     const int N = 16;
-    long A[16];
+    int A[16];
 
     for (i = 0; i < N; i++)
-        A[i] = (long)(i + 1);
+        A[i] = i + 1;
 
-    dill_start_proc(s, "loop_call", DILL_L, "%p%l");
+    dill_start_proc(s, "loop_call", DILL_I, "%p%i");
     pA = dill_vparam(s, 0);
     limit = dill_vparam(s, 1);
 
     off = dill_getreg(s, DILL_L);
-    sum = dill_getreg(s, DILL_L);
-    tmp = dill_getreg(s, DILL_L);
+    sum = dill_getreg(s, DILL_I);
+    tmp = dill_getreg(s, DILL_I);
 
     L_top = dill_alloc_label(s, "loop_top");
     L_end = dill_alloc_label(s, "loop_end");
 
-    dill_mulli(s, limit, limit, (IMM_TYPE)8);
+    dill_mulli(s, limit, limit, (IMM_TYPE)4);
     dill_setl(s, off, (IMM_TYPE)0);
-    dill_setl(s, sum, (IMM_TYPE)0);
+    dill_seti(s, sum, 0);
 
     dill_mark_label(s, L_top);
     dill_bgel(s, off, limit, L_end);
 
     /* tmp = A[off] */
-    dill_ldl(s, tmp, pA, off);
+    dill_ldi(s, tmp, pA, off);
 
     /* call scale_val(tmp) */
     dill_push_init(s);
-    dill_push_argl(s, tmp);
-    ret = dill_calll(s, (void*)scale_val, "scale_val");
+    dill_push_argi(s, tmp);
+    ret = dill_calli(s, (void*)scale_val, "scale_val");
 
     /* sum += return value */
-    dill_addl(s, sum, sum, ret);
+    dill_addi(s, sum, sum, ret);
 
-    dill_addli(s, off, off, (IMM_TYPE)8);
+    dill_addli(s, off, off, (IMM_TYPE)4);
     dill_jv(s, L_top);
     dill_mark_label(s, L_end);
 
-    dill_retl(s, sum);
+    dill_reti(s, sum);
 
     handle = dill_finalize(s);
-    func = (long (*)(long*, long))dill_get_fp(handle);
+    func = (int (*)(int*, int))dill_get_fp(handle);
 
     if (verbose)
         dill_dump(s);
 
     {
-        long result = (*func)(A, (long)N);
+        int result = (*func)(A, N);
         /* sum = 2 * sum(1..16) = 2 * 136 = 272 */
-        long expected = 272;
+        int expected = 272;
         if (result != expected) {
             if (verbose)
-                printf("  loop_call: result = %ld, expected %ld\n", result,
+                printf("  loop_call: result = %d, expected %d\n", result,
                        expected);
             failure = 1;
         }


### PR DESCRIPTION
Cross-block virtual registers (those live across basic block boundaries) are now pre-assigned to physical registers before code emission. This eliminates spill/reload overhead for loop-carried values like pointers and indices, which previously caused extra memory operations per loop iteration.

The allocator scans for cross-block vregs, prioritizes by use count, and pins the most-used to callee-saved registers. A reserve check ensures the on-demand allocator retains enough registers for non-pre-assigned vregs. Pre-assigned registers are preserved across block boundaries in spill_current_pregs() and reset_reg_state().

Includes 6 new virtual-mode tests covering array loops, register pressure overflow, mixed int/float, nested loops, diamond control flow, and loops with function calls.

Bumps version to 3.4.0.