### PR TITLE
Fix free_code_blocks unmapping wrong buffer

### DIFF
--- a/dill_util.c
+++ b/dill_util.c
@@ -951,13 +951,13 @@ free_code_blocks(dill_stream s)
         (s->p->virtual.code_base != s->p->code_base)) {
         int vsize = (long)s->p->virtual.code_limit -
                     (long)s->p->virtual.code_base + END_OF_CODE_BUFFER;
-        if (munmap(s->p->code_base, vsize) == -1)
+        if (munmap(s->p->virtual.code_base, vsize) == -1)
             perror("unmap v");
     }
     if (s->p->native.code_base && (s->p->native.code_base != s->p->code_base)) {
         int nsize = (long)s->p->native.code_limit -
                     (long)s->p->native.code_base + END_OF_CODE_BUFFER;
-        if (munmap(s->p->code_base, nsize) == -1)
+        if (munmap(s->p->native.code_base, nsize) == -1)
             perror("unmap n");
     }
 #else


### PR DESCRIPTION
free_code_blocks passed s->p->code_base to the 2nd/3rd munmap instead of virtual.code_base/native.code_base. This unmapped code_base up to 3x with mismatched sizes (tearing down adjacent live mappings) and did munmap(NULL,...) when code_base was NULL.

Two fixes in one:
- Correctness: a stray oversized munmap could free a live neighbor mapping. Surfaced as an intermittent SIGSEGV in ffs adios2_bug (clang release) where it freed the page holding libffs link_map l_versions, faulting the next lazy PLT resolve. 3000/3000 crashes -> 0/3000.
- Leak: the virtual and native code buffers were never actually unmapped (munmap hit code_base/NULL), leaking on every code generation. The malloc #else branch already frees the correct buffers; this makes the mmap branch match.