### PR TITLE
Move Windows CI jobs to windows-2025 / Visual Studio 2026

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -210,17 +210,17 @@ jobs:
       matrix:
         buildtype: [ release, debug ]
         jobname: [
-          windows2022-vs2022-clang,
-          windows2025-vs2022-msvc,
-          windows2022-vs2022-msvc-win32,
+          windows2025-vs2026-clang,
+          windows2025-vs2026-msvc,
+          windows2025-vs2026-msvc-win32,
           macos-clang ]
         include:
-        - jobname: windows2022-vs2022-clang
-          vm: windows-2022
-        - jobname: windows2025-vs2022-msvc
+        - jobname: windows2025-vs2026-clang
           vm: windows-2025
-        - jobname: windows2022-vs2022-msvc-win32
-          vm: windows-2022
+        - jobname: windows2025-vs2026-msvc
+          vm: windows-2025
+        - jobname: windows2025-vs2026-msvc-win32
+          vm: windows-2025
         - jobname: macos-clang
           vm: macos-latest
 

--- a/scripts/ci/cmake/windows2025-vs2026-clang.cmake
+++ b/scripts/ci/cmake/windows2025-vs2026-clang.cmake
@@ -1,7 +1,9 @@
 # Client maintainer: chuck.atkins@kitware.com
 
-set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
+# windows-2025 runner image ships Visual Studio 2026; needs CMake >= 4.2
+set(CTEST_CMAKE_GENERATOR "Visual Studio 18 2026")
 set(CTEST_CMAKE_GENERATOR_PLATFORM x64)
+set(CTEST_CMAKE_GENERATOR_TOOLSET ClangCL)
 
 list(APPEND CTEST_UPDATE_NOTES_FILES "${CMAKE_CURRENT_LIST_FILE}")
 include(${CMAKE_CURRENT_LIST_DIR}/windows-common.cmake)

--- a/scripts/ci/cmake/windows2025-vs2026-msvc-win32.cmake
+++ b/scripts/ci/cmake/windows2025-vs2026-msvc-win32.cmake
@@ -1,6 +1,7 @@
 # Client maintainer: eisen@cc.gatech.edu
 
-set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
+# windows-2025 runner image ships Visual Studio 2026; needs CMake >= 4.2
+set(CTEST_CMAKE_GENERATOR "Visual Studio 18 2026")
 set(CTEST_CMAKE_GENERATOR_PLATFORM Win32)
 
 list(APPEND CTEST_UPDATE_NOTES_FILES "${CMAKE_CURRENT_LIST_FILE}")

--- a/scripts/ci/cmake/windows2025-vs2026-msvc.cmake
+++ b/scripts/ci/cmake/windows2025-vs2026-msvc.cmake
@@ -1,8 +1,8 @@
 # Client maintainer: chuck.atkins@kitware.com
 
-set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
+# windows-2025 runner image ships Visual Studio 2026; needs CMake >= 4.2
+set(CTEST_CMAKE_GENERATOR "Visual Studio 18 2026")
 set(CTEST_CMAKE_GENERATOR_PLATFORM x64)
-set(CTEST_CMAKE_GENERATOR_TOOLSET ClangCL)
 
 list(APPEND CTEST_UPDATE_NOTES_FILES "${CMAKE_CURRENT_LIST_FILE}")
 include(${CMAKE_CURRENT_LIST_DIR}/windows-common.cmake)


### PR DESCRIPTION
- windows-2025 image now ships VS 2026, breaking the `Visual Studio 17 2022` generator
- Move all Windows jobs to windows-2025 / `Visual Studio 18 2026`, keeping the ClangCL/MSVC/Win32 spread; drop windows-2022